### PR TITLE
feat: filter and validate uom in item with is purity item

### DIFF
--- a/aumms/aumms/doc_events/item.py
+++ b/aumms/aumms/doc_events/item.py
@@ -1,0 +1,30 @@
+import frappe
+from frappe import _
+
+@frappe.whitelist()
+def validate_item(doc, method):
+    """
+        method used to validate item doc
+        args:
+            doc: object of item document
+            method: validate of item
+    """
+    # check stock uom is a purity uom
+    if doc.stock_uom:
+        uom_is_a_purity_uom(doc.stock_uom)
+    # check sales uom is a purity uom
+    if doc.sales_uom:
+        uom_is_a_purity_uom(doc.sales_uom)
+    # check purchase uom is a purity uom
+    if doc.purchase_uom:
+        uom_is_a_purity_uom(doc.purchase_uom)
+
+def uom_is_a_purity_uom(uom):
+    """
+        function to check uom is a purity uom
+        args:
+            uom: name of uom document
+        output: a message iff uom is not a purity uom 
+    """
+    if not frappe.db.exists('UOM', {'name': uom, 'is_purity_uom': 1}):
+        frappe.throw(_('{} is not a purity uom'.format(uom)))

--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -29,7 +29,7 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-# doctype_js = {"doctype" : "public/js/doctype.js"}
+doctype_js = {'Item': 'public/js/item.js'}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
@@ -102,13 +102,11 @@ app_license = "MIT"
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-#	"*": {
-#		"on_update": "method",
-#		"on_cancel": "method",
-#		"on_trash": "method"
-#	}
-# }
+doc_events = {
+	'Item': {
+        'validate': 'aumms.aumms.doc_events.item.validate_item'
+	}
+}
 
 # Scheduled Tasks
 # ---------------

--- a/aumms/public/js/item.js
+++ b/aumms/public/js/item.js
@@ -1,0 +1,25 @@
+frappe.ui.form.on('Item', {
+    onload(frm) {
+        // show only uoms which is purity uom checked for stock_uom
+        set_filter('stock_uom', {is_purity_uom: 1})
+        // show only uoms which is purity uom checked for purchase_uom
+        set_filter('purchase_uom', {is_purity_uom: 1})
+        // show only uoms which is purity uom checked for sales_uom
+        set_filter('sales_uom', {is_purity_uom: 1})
+    }
+})
+
+let set_filter = function(field, filters) {
+    /*
+        function to set filter for a specific field
+        args:
+            field: field name
+            filters: set of filters, (eg: {key:value})
+        output: filter applied list for field
+    */
+    cur_frm.set_query(field, () => {
+        return {
+            filters: filters
+        }
+    })
+}


### PR DESCRIPTION
## Feature description

In Item filter and Validate set for Stock UOM, Sales UOM, Purchase UOM by Is Purity UOM

## Analysis and design (optional)
filter for uom:
for stock uom-
![image](https://user-images.githubusercontent.com/105269688/210760509-e5c4db35-e417-48fb-b038-19e2f3f414e4.png)

for purchase uom-
![image](https://user-images.githubusercontent.com/105269688/210760624-43e34e13-bb8c-467c-a557-b862ff6e8f67.png)

for sales uom-
![image](https://user-images.githubusercontent.com/105269688/210760706-cf3e03c7-f849-4200-b8e8-30a48ef6f6f9.png)


Validation for uom:

![Screenshot from 2023-01-05 15-52-49](https://user-images.githubusercontent.com/105269688/210759668-c08e4566-bd21-4f33-8139-da3224de8eda.png)


## Was this feature tested on the browsers?
  - Chrome
