### PR TITLE
fix: Validate purity percentage

### DIFF
--- a/aumms/aumms/doctype/purity/purity.json
+++ b/aumms/aumms/doctype/purity/purity.json
@@ -10,7 +10,6 @@
  "engine": "InnoDB",
  "field_order": [
   "purity",
-  "column_break_2",
   "purity_percentage",
   "amended_from"
  ],
@@ -24,13 +23,10 @@
    "unique": 1
   },
   {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "purity_percentage",
    "fieldtype": "Percent",
    "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Purity Percentage",
    "reqd": 1
   },
@@ -56,7 +52,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-05 14:44:20.669850",
+ "modified": "2023-01-06 16:24:10.251651",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Purity",

--- a/aumms/aumms/doctype/purity/purity.py
+++ b/aumms/aumms/doctype/purity/purity.py
@@ -1,8 +1,19 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe import _
+
 
 class Purity(Document):
-	pass
+	def validate(self):
+		self.validate_purity_percentage()
+
+	def validate_purity_percentage(self):
+		#Method to validate Purity Percentage#
+		if self.purity_percentage < 0 or self.purity_percentage > 100:
+			frappe.throw(
+				title = _('ALERT !!'),
+				msg = _(' Purity Percentage must range from 0 to 100')
+				)


### PR DESCRIPTION
## Feature description
->Validate purity percentage : purity percentage must be in between 0 and 100
->Edit Purity Percentage remove column break and add In filter


## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome -yes

## Output screenshots 
![Screenshot from 2023-01-06 17-35-53](https://user-images.githubusercontent.com/114916803/211130448-1f908fcb-2993-4b32-8bb7-618404e44b47.png)
![Screenshot from 2023-01-06 17-35-31](https://user-images.githubusercontent.com/114916803/211130460-ccfd72e2-2c88-4ca9-8412-94f6684aba1e.png)
![Screenshot from 2023-01-07 09-38-03](https://user-images.githubusercontent.com/114916803/211130468-18b7b2f3-8c78-445b-b651-d23dff572a1c.png)




