### PR TITLE
fix: validation for uom in board rate with is purity uom

### DIFF
--- a/aumms/aumms/doctype/board_rate/board_rate.py
+++ b/aumms/aumms/doctype/board_rate/board_rate.py
@@ -1,8 +1,23 @@
 # Copyright (c) 2023, efeone and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe import _
 
 class BoardRate(Document):
-	pass
+	def validate(self):
+
+		# check uom is a purity uom
+		if self.uom:
+			uom_is_a_purity_uom(self.uom)
+
+def uom_is_a_purity_uom(uom):
+	"""
+	function to check uom is a purity uom
+		args:
+			uom: name of uom document
+		output: a message iff uom is not a purity uom
+	"""
+	if not frappe.db.exists('UOM', {'name': uom, 'is_purity_uom': 1}):
+		frappe.throw(_('{} is not a purity uom'.format(uom)))


### PR DESCRIPTION
## Feature description

validation for uom in board rate doctype if selected uom is not a purity uom

## Analysis and design (optional)

![Screenshot from 2023-01-07 12-26-57](https://user-images.githubusercontent.com/105269688/211147904-07a2399e-ca14-4bf1-9cd4-113e0da1645f.png)



## Was this feature tested on the browsers?
  - Chrome
