### PR TITLE
fix: Clearing uoms table in item before appending uoms

### DIFF
--- a/aumms/public/js/item.js
+++ b/aumms/public/js/item.js
@@ -39,6 +39,10 @@ let append_purity_uoms = function (frm) {
     let uoms = []
     let existing_uom = get_existing_uoms(uoms)
 
+    // clear uom table
+    frm.clear_table('uoms');
+    frm.refresh_field('uoms');
+
     // check uom not in exising uom list and add first uom
     if (!existing_uom.includes(frm.doc.stock_uom)) {
         frm.add_child('uoms', {


### PR DESCRIPTION

## Feature description
->Clear uoms table in item before appending Uoms


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
 
## Output screenshots 
![Screenshot from 2023-01-09 09-25-26](https://user-images.githubusercontent.com/114916803/211238742-8303056b-71b4-43a4-940f-4ec4ba31a757.png)
![Screenshot from 2023-01-09 09-27-14](https://user-images.githubusercontent.com/114916803/211238850-983045a4-3610-4ebe-b0f9-cd5dd96da318.png)

