### PR TITLE
fix: set item type in item group read only if parent item group have …

### DIFF
--- a/aumms/aumms/custom/item_group.json
+++ b/aumms/aumms/custom/item_group.json
@@ -232,7 +232,7 @@
    "print_hide_if_no_value": 0,
    "print_width": null,
    "read_only": 0,
-   "read_only_depends_on": "eval:doc.item_type &&doc.parent_item_group",
+   "read_only_depends_on": "",
    "report_hide": 0,
    "reqd": 0,
    "search_index": 0,

--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -29,8 +29,11 @@ app_license = "MIT"
 # page_js = {"page" : "public/js/file.js"}
 
 # include js in doctype views
-doctype_js = {'Item': 'public/js/item.js',
-'Sales Invoice':'public/js/sales_invoice.js'}
+doctype_js = {
+	'Item': 'public/js/item.js',
+	'Sales Invoice':'public/js/sales_invoice.js',
+	'Item Group': 'public/js/item_group.js'
+	}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/aumms/public/js/item_group.js
+++ b/aumms/public/js/item_group.js
@@ -1,0 +1,20 @@
+frappe.ui.form.on('Item Group', {
+
+    parent_item_group(frm) {
+
+        // set item_type as read and write
+        frm.set_df_property('item_type', 'read_only', 0)
+
+        if (frm.doc.parent_item_group) {
+            // call to get item type from parent item group
+            frappe.db.get_value('Item Group', frm.doc.parent_item_group, 'item_type')
+                .then(r => {
+                    if (r.message.item_type) {
+                        // set item_type as read only
+                        frm.set_df_property('item_type', 'read_only', 1)
+                    }
+                })
+        }
+    }
+
+})


### PR DESCRIPTION
## Feature description

set item type in item group read only if parent item group have item type

## Analysis and design (optional)

![image](https://user-images.githubusercontent.com/105269688/211248319-98308470-81c2-4f35-80d8-760f6a3cc4d8.png)


## Was this feature tested on the browsers?
  - Chrome
