### PR TITLE
fix: validation for purity percentage on change of field

### DIFF
--- a/aumms/aumms/doctype/purity/purity.js
+++ b/aumms/aumms/doctype/purity/purity.js
@@ -2,7 +2,23 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Purity', {
-	// refresh: function(frm) {
 
-	// }
+	purity_percentage (frm) {
+
+		if (frm.doc.purity_percentage) {
+
+			// check purity percentage is not between 0 and 100
+			if(0 > frm.doc.purity_percentage || frm.doc.purity_percentage  > 100) {
+
+				// message for user about purity percentage range
+				frappe.throw({
+					title: __('ALERT !!'),
+					message: __('Purity Percentage must range from 0 to 100')
+				});
+
+			}
+		}
+
+	}
+
 });


### PR DESCRIPTION
## Feature description

validation for purity percentage on change of field purity percentage ( if value is not in between 0 and 100)


## Analysis and design (optional)

![image](https://user-images.githubusercontent.com/105269688/211482497-8f8365ff-070c-4ac7-bc6c-9ed5f8fcc950.png)


## Was this feature tested on the browsers?
  - Chrome
