### PR TITLE
fix: validate date for board rate over item type

### DIFF
--- a/aumms/aumms/doctype/board_rate/board_rate.json
+++ b/aumms/aumms/doctype/board_rate/board_rate.json
@@ -8,14 +8,15 @@
  "engine": "InnoDB",
  "field_order": [
   "naming_series",
-  "board_rate",
+  "broad_rate_details",
   "item_type",
-  "purity_mandatory",
+  "purity",
   "uom",
-  "column_break_4",
+  "column_break_3",
   "date",
   "time",
-  "purity",
+  "purity_mandatory",
+  "board_rate",
   "amended_from"
  ],
  "fields": [
@@ -76,10 +77,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "item_type",
    "fieldtype": "Link",
    "label": "Item Type",
@@ -94,12 +91,21 @@
    "hidden": 1,
    "label": "Purity Mandatory",
    "read_only": 1
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "broad_rate_details",
+   "fieldtype": "Section Break",
+   "label": "Board Rate Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-01-06 13:24:16.055342",
+ "modified": "2023-01-10 16:25:34.729702",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Board Rate",

--- a/aumms/aumms/doctype/board_rate/board_rate.py
+++ b/aumms/aumms/doctype/board_rate/board_rate.py
@@ -12,6 +12,9 @@ class BoardRate(Document):
 		if self.uom:
 			uom_is_a_purity_uom(self.uom)
 
+		# check validation over date
+		time_validation_for_boardrate(self.date, self.time, self.item_type)
+
 def uom_is_a_purity_uom(uom):
 	"""
 	function to check uom is a purity uom
@@ -21,3 +24,11 @@ def uom_is_a_purity_uom(uom):
 	"""
 	if not frappe.db.exists('UOM', {'name': uom, 'is_purity_uom': 1}):
 		frappe.throw(_('{} is not a purity uom'.format(uom)))
+
+def time_validation_for_boardrate(date, time, item_type):
+	"""
+	function to validate date for board rate over item type
+	"""
+
+	if frappe.db.exists('Board Rate', {'date': date, 'time': time, 'item_type': item_type, 'docstatus': 1}):
+		frappe.throw(_("{}'s board rate is already set on {} at {} ".format(item_type, date, time)))


### PR DESCRIPTION
## Feature description
validate date for board rate over item type

## Was this feature tested on the browsers?
  - Chrome -  Yes
![Screenshot from 2023-01-10 16-27-09](https://user-images.githubusercontent.com/103920312/211537314-9c70b5ca-e77a-4001-8d7d-3a3ca444f501.png)

