### PR TITLE
feat: Enabled the is metal transaction checkbox in purchase receipt item

### DIFF
--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -32,7 +32,8 @@ app_license = "MIT"
 doctype_js = {
 	'Item': 'public/js/item.js',
 	'Sales Invoice':'public/js/sales_invoice.js',
-	'Item Group': 'public/js/item_group.js'
+	'Item Group': 'public/js/item_group.js',
+	'Purchase Receipt': 'public/js/purchase_receipt.js'
 	}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/aumms/public/js/purchase_receipt.js
+++ b/aumms/public/js/purchase_receipt.js
@@ -1,0 +1,37 @@
+frappe.ui.form.on('Purchase Receipt', {
+  is_metal_transaction (frm) {
+    //Check is metal transaction
+    if(frm.doc.is_metal_transaction){
+      change_is_metal_transaction(frm, 1)
+    }
+    else{
+      change_is_metal_transaction(frm, 0)
+    }
+    frm.refresh_field('items')
+  }
+});
+
+frappe.ui.form.on('Purchase Receipt Item',{
+  items_add(frm, cdt, cdn){
+    let child = locals[cdt][cdn]
+    //Check is metal transaction
+    if(frm.doc.is_metal_transaction){
+      //set value to the field is is_metal_transaction as 1
+      frappe.model.set_value(child.doctype, child.name, 'is_metal_transaction', 1)
+    }
+  }
+
+});
+
+
+let change_is_metal_transaction = function (frm, value){
+  /*
+    function to iterate item table and set value to the field is_metal_transaction
+    args:
+      frm: current form of purchase Receipt
+      value: Boolean
+  */
+  frm.doc.items.forEach((item) => {
+    item.is_metal_transaction = value
+  });
+}


### PR DESCRIPTION
## Feature description
-> Enabled the is metal transaction checkbox in purchase receipt item 
->  is metal transaction checkbox  is default checked iff purchase receipt is metal transaction



## Is there any existing behavior change of other features due to this code change?
 No
## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots 

-> is metal transaction is checked in purchase receipt
![Screenshot from 2023-01-11 14-59-13](https://user-images.githubusercontent.com/115983752/211774097-e7a99e47-5081-4db9-88cf-030a37e1bdbb.png)

-> child table purchase receipt item
![Screenshot from 2023-01-11 14-59-42](https://user-images.githubusercontent.com/115983752/211774082-b6a6a552-550a-45f6-b618-54d743a8805b.png)
