### PR TITLE
feat: metal ledger entry cancellation for voucher purchase receipt

### DIFF
--- a/aumms/aumms/doctype/metal_ledger_entry/metal_ledger_entry.json
+++ b/aumms/aumms/doctype/metal_ledger_entry/metal_ledger_entry.json
@@ -133,6 +133,7 @@
    "fieldname": "is_cancelled",
    "fieldtype": "Check",
    "label": "Is Cancelled",
+   "read_only": 1,
    "report_hide": 1
   },
   {
@@ -202,7 +203,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-01-12 11:46:46.674057",
+ "modified": "2023-01-13 10:25:54.081353",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Metal Ledger Entry",

--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -116,7 +116,8 @@ doc_events = {
 		'autoname': 'aumms.aumms.doc_events.item_group.autoname_item_group'
     },
 	'Purchase Receipt': {
-		'on_submit': 'aumms.aumms.utils.create_metal_ledger_entries'
+		'on_submit': 'aumms.aumms.utils.create_metal_ledger_entries',
+		'on_cancel': 'aumms.aumms.utils.cancel_metal_ledger_entries'
 	}
 }
 


### PR DESCRIPTION
## Feature description

purchase receipt cancellation impact on metal ledger entry
cancelling existing metal ledger entry doc with voucher type purchase receipt and creating new metal ledger entry with quantity and amount change

## Analysis and design (optional)

[Screencast from 13-01-23 10:59:17 AM IST.webm](https://user-images.githubusercontent.com/105269688/212244441-913a3033-1489-4fe5-bedc-963cd97694a0.webm)


metal ledger entry after cancelling purchase receipt for one item Ring:

old metal ledger entry

![Screenshot from 2023-01-13 10-53-13](https://user-images.githubusercontent.com/105269688/212243767-1e82b688-9a9f-497e-ab08-e007a5759735.png)

new metal ledger entry

![Screenshot from 2023-01-13 10-53-20](https://user-images.githubusercontent.com/105269688/212243993-41ce1aec-4f6b-4ce7-b9ec-540b6f857aa2.png)



## Was this feature tested on the browsers?
  - Chrome

