### PR TITLE
feat: Created metal ledger entry for Keep Metal Ledger transaction of  Sales Invoice

### DIFF
--- a/aumms/aumms/utils.py
+++ b/aumms/aumms/utils.py
@@ -20,8 +20,8 @@ def create_metal_ledger_entries(doc, method=None):
     """
         method to create metal ledger entries
         args:
-            doc: object of purchase Receipt doctype
-            method: on submit of purchase reciept
+            doc: object of purchase Receipt doctype and Sales Invoice doctype
+            method: on submit of purchase reciept and Sales Invoice
         output:
             new metal ledger entry doc
     """
@@ -44,10 +44,15 @@ def create_metal_ledger_entries(doc, method=None):
         fields['party_type'] = 'Supplier'
         fields['party'] = doc.supplier
 
+    # set party type and party in fields if doctype is Sales Invoice
+    if doc.doctype == 'Sales Invoice':
+        fields['party_type'] = 'Customer'
+        fields['party'] = doc.customer
+
     # declare ledger_created as false
     ledger_created = 0
     for item in doc.items:
-        # check item is a metal transaction
+        # check item is keep_metal_ledger
         if item.keep_metal_ledger:
 
             # set item details in fields
@@ -55,7 +60,8 @@ def create_metal_ledger_entries(doc, method=None):
             fields['item_name'] = item.item_name
             fields['stock_uom'] = item.stock_uom
             fields['purity'] = item.purity
-            fields['purity_percentage'] = item.purity_percentage
+            if doc.doctype == 'Purchase Receipt':
+                fields['purity_percentage'] = item.purity_percentage
             fields['qty'] = item.stock_qty
             fields['board_rate'] = item.rate
             fields['outgoing_rate'] = item.rate
@@ -81,8 +87,8 @@ def cancel_metal_ledger_entries(doc, method=None):
     """
         method to cancel metal ledger entries of this voucher and create new entries
         args:
-            doc: object of purchase receipt
-            method: on cancel of purchase receipt
+            doc: object of purchase receipt and Sales Invoice
+            method: on cancel of purchase receipt and Sales Invoice
     """
     # get all Metal Ledger Entry linked with this doctype
     ml_entries = frappe.db.get_all('Metal Ledger Entry', {

--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -122,6 +122,12 @@ doc_events = {
 			  'aumms.aumms.doc_events.purchase_receipt.create_purchase_invoice'
 		],
 		'on_cancel': 'aumms.aumms.utils.cancel_metal_ledger_entries'
+	},
+	'Sales Invoice': {
+		'on_submit': [
+			  'aumms.aumms.utils.create_metal_ledger_entries'
+		],
+		'on_cancel': 'aumms.aumms.utils.cancel_metal_ledger_entries'
 	}
 }
 


### PR DESCRIPTION


## Feature description
-> Created metal ledger entry for Keep Metal Ledger transaction of  Sales Invoice




## Is there any existing behavior change of other features due to this code change?
   - No
## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots 

-> Added customer and items to Sales Invoice and checked keep metal ledger

![Screenshot from 2023-01-20 12-10-51](https://user-images.githubusercontent.com/115983752/213672957-97a2d1f3-0fb4-4009-a718-b622c7b836fb.png)

-> On the submission of Sales Invoice the Metal Ledger entry is created

![Screenshot from 2023-01-20 12-12-11](https://user-images.githubusercontent.com/115983752/213672961-c1246f86-cfa5-4f97-b2a8-fcecd6eb69fb.png)

-> Metal ledger entry List

![Screenshot from 2023-01-20 12-12-31](https://user-images.githubusercontent.com/115983752/213672968-46b2edda-84d4-47dd-adb1-4887a811978b.png)

-> Cancelled the Sales Invoice

![Screenshot from 2023-01-20 12-18-10](https://user-images.githubusercontent.com/115983752/213672965-725374f7-4a31-4798-b2f7-1edd9dec9a72.png)

-> Cancelled both Metal Ledger entry 

![Screenshot from 2023-01-20 12-19-15](https://user-images.githubusercontent.com/115983752/213672973-921a313b-0e6f-458b-98a6-72fdaf9d4f44.png)
![Screenshot from 2023-01-20 12-19-03](https://user-images.githubusercontent.com/115983752/213672975-afd7ef6f-1816-4b91-a6ce-f46d18f3af7d.png)
