### PR TITLE
feat: validation for user if party is not linked for common party acc…

### DIFF
--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -117,6 +117,7 @@ doc_events = {
 		'autoname': 'aumms.aumms.doc_events.item_group.autoname_item_group'
     },
 	'Purchase Receipt': {
+		'before_submit': 'aumms.aumms.utils.validate_party_for_metal_transaction',
 		'on_submit': [
 			  'aumms.aumms.utils.create_metal_ledger_entries',
 			  'aumms.aumms.doc_events.purchase_receipt.create_purchase_invoice'
@@ -124,6 +125,7 @@ doc_events = {
 		'on_cancel': 'aumms.aumms.utils.cancel_metal_ledger_entries'
 	},
 	'Sales Invoice': {
+		'before_submit': 'aumms.aumms.utils.validate_party_for_metal_transaction',
 		'on_submit': [
 			  'aumms.aumms.utils.create_metal_ledger_entries'
 		],


### PR DESCRIPTION
…ount

## Feature description

Validation for keep metal ledger on purchase and sales with common party account

## Analysis and design (optional)

Sales Invoice:

![image](https://user-images.githubusercontent.com/105269688/213861541-bd045eb2-ffb1-45bf-8c27-b76b0c0fc513.png)

Purchase Receipt:

![image](https://user-images.githubusercontent.com/105269688/213861581-6de51750-275d-4240-9e7f-b55bf32164ee.png)


## Solution description

checking the party is linked as primary party or secondary party in Party Link

## Was this feature tested on the browsers?
  - Chrome