### PR TITLE
fix: Changing the Board Rate on changing of Posting Date and Posting Time

### DIFF
--- a/aumms/public/js/purchase_receipt.js
+++ b/aumms/public/js/purchase_receipt.js
@@ -21,7 +21,27 @@ frappe.ui.form.on('Purchase Receipt', {
 
     }
 
+  },
+
+  posting_date(frm){
+    //Changing the board rate on the changing of posting_date
+    if(frm.doc.posting_date && frm.doc.posting_time) {
+      frm.doc.items.forEach((child) => {
+        //call to get board_rate
+        set_board_rate(child)
+    });
   }
+},
+
+posting_time(frm){
+  //Changing the board rate on the changing of posting_time
+  if(frm.doc.posting_date && frm.doc.posting_time) {
+    frm.doc.items.forEach((child) => {
+      //call to get board_rate
+      set_board_rate(child)
+   });
+ }
+}
 });
 
 frappe.ui.form.on('Purchase Receipt Item', {
@@ -40,24 +60,7 @@ frappe.ui.form.on('Purchase Receipt Item', {
       //to make delay in board_rate entry
       setTimeout(function () {
         //call to get board_rate
-        frappe.call({
-          method: 'aumms.aumms.utils.get_board_rate',
-          args: {
-            item_code: child.item_code,
-            item_type: child.item_type,
-            date: frm.doc.posting_date,
-            time: frm.doc.posting_time,
-            purity: child.purity
-          },
-          callback: function (r) {
-            if (r.message) {
-
-              //set value to rate field
-              frappe.model.set_value(child.doctype, child.name, 'board_rate', r.message)
-
-            }
-          }
-        })
+        set_board_rate(child)
       }, 500);
     }
 
@@ -98,4 +101,26 @@ let change_keep_metal_ledger = function (frm, value) {
   frm.doc.items.forEach((item) => {
     item.keep_metal_ledger = value
   });
+}
+
+
+let set_board_rate = function (child) {
+  //function to set board rate
+  if (child.item_type){
+    frappe.call({
+        method : 'aumms.aumms.utils.get_board_rate',
+        args: {
+          item_code: child.item_code,
+          item_type: child.item_type,
+          date: cur_frm.doc.posting_date,
+          time: cur_frm.doc.posting_time,
+          purity: child.purity
+        },
+        callback : function(r) {
+          if (r.message) {
+            frappe.model.set_value(child.doctype, child.name, 'board_rate', r.message)
+          }
+        }
+    })
+ }
 }


### PR DESCRIPTION


## Feature description
Changing the Board Rate on changing of Posting Date and Posting Time in both Sales Invoice and Purchase Receipt





## Is there any existing behavior change of other features due to this code change?
   - No

## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots 
IN SALES INVOICE

changed posting date in sales invoice

![Screenshot from 2023-01-23 16-50-01](https://user-images.githubusercontent.com/115983752/214027425-8c5198a5-0be5-483a-b9a6-86561189ce3b.png)

Board Rate on 5/1/2023

![Screenshot from 2023-01-23 16-50-17](https://user-images.githubusercontent.com/115983752/214028470-1245d5da-7d9e-40bd-9691-08848adc4e03.png)



Date again changed into 23/01

![Screenshot from 2023-01-23 16-50-01](https://user-images.githubusercontent.com/115983752/214027757-9802c78d-0a19-4a5d-8ae7-c0b526f7e3dd.png)

Board rate on 23/01

![Screenshot from 2023-01-23 16-50-35](https://user-images.githubusercontent.com/115983752/214028541-8812b1c8-931e-4ebd-be09-8c25ea629ff3.png)

IN PURCHASE RECEIPT

Set date on 23/01

![Screenshot from 2023-01-23 16-59-09](https://user-images.githubusercontent.com/115983752/214029255-f547326e-a914-47b9-be13-2f8ef816868d.png)

Board Rate on 23/01

![Screenshot from 2023-01-23 16-59-16](https://user-images.githubusercontent.com/115983752/214029381-1d9e8ea8-cdf9-4c36-b73e-9766151c4148.png)

Date again changed into 5/01

![Screenshot from 2023-01-23 16-59-32](https://user-images.githubusercontent.com/115983752/214029522-7ac93b3d-b27d-4486-b96b-a86e474ab263.png)

Board Rate on 05/01

![Screenshot from 2023-01-23 16-59-37](https://user-images.githubusercontent.com/115983752/214029668-9eb539a4-2cb0-4474-8724-03a9dfd71fbd.png)

