### PR TITLE
fix:  board rate fetch configuration

### DIFF
--- a/aumms/aumms/doc_events/sales_invoice.py
+++ b/aumms/aumms/doc_events/sales_invoice.py
@@ -2,7 +2,7 @@ import frappe
 from aumms.aumms.utils import *
 
 @frappe.whitelist()
-def get_item_details(item_code, item_type, date, time, purity):
+def get_item_details(item_code, item_type, date, time, purity, stock_uom):
     ''' Method for fetching qty, making_charge_percentage, making_charge & board_rate '''
     item_details = { 'qty':0, 'making_charge_percentage':0, 'making_charge':0,  'board_rate':0  }
     if item_code:
@@ -11,7 +11,5 @@ def get_item_details(item_code, item_type, date, time, purity):
         item_details['qty'] = item_doc.weight_per_unit
         item_details['making_charge_percentage'] = item_doc.making_charge_percentage
         item_details['making_charge'] = item_doc.making_charge
-        if frappe.db.exists('Board Rate', {'item_type':item_type, 'purity':purity}):
-            board_rate_doc = frappe.get_last_doc('Board Rate', filters = {'item_type':item_type, 'purity':purity})
-            item_details['board_rate'] = board_rate_doc.board_rate
+        item_details['board_rate'] = get_board_rate(item_type, purity, stock_uom, date, time)
     return item_details

--- a/aumms/public/js/purchase_receipt.js
+++ b/aumms/public/js/purchase_receipt.js
@@ -110,8 +110,8 @@ let set_board_rate = function (child) {
     frappe.call({
         method : 'aumms.aumms.utils.get_board_rate',
         args: {
-          item_code: child.item_code,
           item_type: child.item_type,
+          stock_uom: child.stock_uom,
           date: cur_frm.doc.posting_date,
           time: cur_frm.doc.posting_time,
           purity: child.purity

--- a/aumms/public/js/sales_invoice.js
+++ b/aumms/public/js/sales_invoice.js
@@ -41,36 +41,37 @@ frappe.ui.form.on('Sales Invoice Item', {
  item_code: function(frm, cdt, cdn){
     let d = locals[cdt][cdn];
     if (d.item_code){
-      frappe.call({
-        // Method for fetching  qty, making_charge_percentage, making_charge & board_rate
-        method: 'aumms.aumms.doc_events.sales_invoice.get_item_details',
-        args: {
-          'item_code': d.item_code,
-          'item_type': d.item_type,
-          'date': frm.doc.posting_date,
-          'time': frm.doc.posting_time,
-          'purity': d.purity
-        },
-        callback: function(r) {
-          if (r.message){
-            d.qty = r.message['qty']
-            d.making_charge_percentage = r.message['making_charge_percentage']
-            d.is_fixed_making_charge = r.message['making_charge']
-            d.board_rate = r.message['board_rate']
-            d.making_charge_based_on = r.message ['making_charge_based_on']
-            d.amount_with_out_making_charge = r.message['qty'] * r.message['board_rate']
-            setTimeout(() => {
-             frappe.model.set_value(d.doctype, d.name, 'rate', (d.amount_with_out_making_charge + d.making_charge)/d.qty)// set time out of 500 ms for  rate
-           }, 500);
-            if (r.message['making_charge']){
-              d.making_charge = r.message['making_charge']
-            }
-            else {
-                d.making_charge = (d.amount_with_out_making_charge)*(d.making_charge_percentage * 0.01)//set making_charge if it's percentage
+      setTimeout(() => {
+        frappe.call({
+          // Method for fetching  qty, making_charge_percentage, making_charge & board_rate
+          method: 'aumms.aumms.doc_events.sales_invoice.get_item_details',
+          args: {
+            'item_code': d.item_code,
+            'item_type': d.item_type,
+            'date': frm.doc.posting_date,
+            'time': frm.doc.posting_time,
+            'purity': d.purity,
+            'stock_uom': d.stock_uom
+          },
+          callback: function(r) {
+            if (r.message){
+              d.qty = r.message['qty']
+              d.making_charge_percentage = r.message['making_charge_percentage']
+              d.is_fixed_making_charge = r.message['making_charge']
+              d.board_rate = r.message['board_rate']
+              d.making_charge_based_on = r.message ['making_charge_based_on']
+              d.amount_with_out_making_charge = r.message['qty'] * r.message['board_rate']
+              frappe.model.set_value(d.doctype, d.name, 'rate', (d.amount_with_out_making_charge + d.making_charge)/d.qty)// set time out of 500 ms for  rate
+              if (r.message['making_charge']){
+                d.making_charge = r.message['making_charge']
               }
+              else {
+                  d.making_charge = (d.amount_with_out_making_charge)*(d.making_charge_percentage * 0.01)//set making_charge if it's percentage
+                }
+            }
           }
-        }
-      })
+        })
+      }, 500);
     }
   },
   qty: function(frm, cdt, cdn){


### PR DESCRIPTION
## Feature description

updated the method for getting board rate according to uom's

## Analysis and design (optional)

boar rate:

![image](https://user-images.githubusercontent.com/105269688/214233126-16ff9e58-e2d9-4e87-8bc2-6993e76b93b9.png)


purchase receipt:

![image](https://user-images.githubusercontent.com/105269688/214232953-d0628350-8e2d-4c6c-8d30-382cbc7ee523.png)

Sales Invoice:

![image](https://user-images.githubusercontent.com/105269688/214233082-179f2b09-f84c-4cee-8d61-d431a55c71b0.png)



## Was this feature tested on the browsers?
  - Chrome