### PR TITLE
fix: uom table getting cleared on changing of stock uom

### DIFF
--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -112,7 +112,8 @@ after_install = 'aumms.aumms.utils.enable_common_party_accounting'
 doc_events = {
 	'Item': {
         'validate': 'aumms.aumms.doc_events.item.validate_item',
-		'before_save': 'aumms.aumms.doc_events.item.check_conversion_factor_for_uom'
+		'before_save': 'aumms.aumms.doc_events.item.check_conversion_factor_for_uom',
+		'on_update': 'aumms.aumms.doc_events.item.update_uoms_table'
 	},
 	'Item Group':{
 		'autoname': 'aumms.aumms.doc_events.item_group.autoname_item_group'


### PR DESCRIPTION
## Feature description

update uoms table on update of item

## Analysis and design (optional)

stock uom = gram

![Screenshot from 2023-01-25 12-34-05](https://user-images.githubusercontent.com/105269688/214501544-3019eae0-2906-451b-84f3-6aeebb1b98b4.png)

stock uom = kg

![image](https://user-images.githubusercontent.com/105269688/214501521-ea106b03-f071-4da1-9925-5da8a10ce6a6.png)



## Was this feature tested on the browsers?
  - Chrome
