### PR TITLE
fix: Fetched Board Rate only for purity item in Sales Invoice and Purchase Receipt

### DIFF
--- a/aumms/public/js/purchase_receipt.js
+++ b/aumms/public/js/purchase_receipt.js
@@ -103,7 +103,7 @@ frappe.ui.form.on('Purchase Receipt Item', {
 
 let set_board_rate = function (child) {
   //function to set board rate
-  if (child.item_type){
+  if (child.item_type && child.is_purity_item) {
     frappe.call({
         method : 'aumms.aumms.utils.get_board_rate',
         args: {

--- a/aumms/public/js/sales_invoice.js
+++ b/aumms/public/js/sales_invoice.js
@@ -52,35 +52,37 @@ frappe.ui.form.on('Sales Invoice Item', {
     let d = locals[cdt][cdn];
     if (d.item_code){
       setTimeout(() => {
-        frappe.call({
-          // Method for fetching  qty, making_charge_percentage, making_charge & board_rate
-          method: 'aumms.aumms.doc_events.sales_invoice.get_item_details',
-          args: {
-            'item_code': d.item_code,
-            'item_type': d.item_type,
-            'date': frm.doc.posting_date,
-            'time': frm.doc.posting_time,
-            'purity': d.purity,
-            'stock_uom': d.stock_uom
-          },
-          callback: function(r) {
-            if (r.message){
-              d.qty = r.message['qty']
-              d.making_charge_percentage = r.message['making_charge_percentage']
-              d.is_fixed_making_charge = r.message['making_charge']
-              d.board_rate = r.message['board_rate']
-              d.making_charge_based_on = r.message ['making_charge_based_on']
-              d.amount_with_out_making_charge = r.message['qty'] * r.message['board_rate']
-              frappe.model.set_value(d.doctype, d.name, 'rate', (d.amount_with_out_making_charge + d.making_charge)/d.qty)// set time out of 500 ms for  rate
-              if (r.message['making_charge']){
-                d.making_charge = r.message['making_charge']
-              }
-              else {
-                  d.making_charge = (d.amount_with_out_making_charge)*(d.making_charge_percentage * 0.01)//set making_charge if it's percentage
+        if (d.is_purity_item){
+          frappe.call({
+            // Method for fetching  qty, making_charge_percentage, making_charge & board_rate
+            method: 'aumms.aumms.doc_events.sales_invoice.get_item_details',
+            args: {
+              'item_code': d.item_code,
+              'item_type': d.item_type,
+              'date': frm.doc.posting_date,
+              'time': frm.doc.posting_time,
+              'purity': d.purity,
+              'stock_uom': d.stock_uom
+            },
+            callback: function(r) {
+              if (r.message){
+                d.qty = r.message['qty']
+                d.making_charge_percentage = r.message['making_charge_percentage']
+                d.is_fixed_making_charge = r.message['making_charge']
+                d.board_rate = r.message['board_rate']
+                d.making_charge_based_on = r.message ['making_charge_based_on']
+                d.amount_with_out_making_charge = r.message['qty'] * r.message['board_rate']
+                frappe.model.set_value(d.doctype, d.name, 'rate', (d.amount_with_out_making_charge + d.making_charge)/d.qty)// set time out of 500 ms for  rate
+                if (r.message['making_charge']){
+                  d.making_charge = r.message['making_charge']
                 }
+                else {
+                    d.making_charge = (d.amount_with_out_making_charge)*(d.making_charge_percentage * 0.01)//set making_charge if it's percentage
+                  }
+              }
             }
-          }
-        })
+          })
+        }
       }, 500);
     }
   },


### PR DESCRIPTION
## Feature description
->  Fetched Board Rate only for purity item in Sales Invoice and Purchase Receipt




## Is there any existing behavior change of other features due to this code change?
  - No

## Was this feature tested on the browsers?
  - Chrome : yes

## Output screenshots
 
PURCHASE RECEIPT

![Screenshot from 2023-02-01 12-38-15](https://user-images.githubusercontent.com/115983752/215975017-c7ac9613-f9b8-4a5a-a4ae-f2ba1b28202a.png)

SALES INVOICE

![Screenshot from 2023-02-01 12-37-44](https://user-images.githubusercontent.com/115983752/215975021-fd07d7e7-15b4-4014-9928-c33df06b52ce.png)

