### PR TITLE
fix: cancelling metal ledger entries

### DIFF
--- a/aumms/aumms/utils.py
+++ b/aumms/aumms/utils.py
@@ -156,7 +156,10 @@ def cancel_metal_ledger_entries(doc, method=None):
         ml_doc.save(ignore_permissions = 1)
 
         # creating new document of metal ledger entry
-        ml_doc.qty = -ml_doc.qty # updating value of qty as minus of existing qty
+        if doc.doctype == 'Purchase Receipt':
+            ml_doc.in_qty = -ml_doc.in_qty
+        if doc.doctype == 'Sales Invoice':
+            ml_doc.out_qty = -ml_doc.out_qty # updating value of qty as minus of existing qty
 
         # changing outgoing rate to incoming rate
         ml_doc.incoming_rate = ml_doc.outgoing_rate


### PR DESCRIPTION
## Issue description
-> Fix issue while cancelling sales invoice and purchase receipt

## Solution description
-> change the field name qty to in_qty and out_qty 


## Is there any existing behaviour change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome


## Output screenshots
![Screenshot from 2023-02-07 11-50-31](https://user-images.githubusercontent.com/114916803/217165630-85f2b05d-88b9-489b-b0b5-0a5b169c5f99.png)


![Screenshot from 2023-02-07 12-00-09](https://user-images.githubusercontent.com/114916803/217165825-50aee5ed-0de4-4f4f-864a-12cb92042e4b.png)
