### PR TITLE
fix: balance qty of a party in conversion tool

### DIFF
--- a/aumms/aumms/doctype/conversion_chart/conversion_chart.json
+++ b/aumms/aumms/doctype/conversion_chart/conversion_chart.json
@@ -14,7 +14,8 @@
   "stock_uom",
   "purity_to_be_obtained",
   "alloy_weight",
-  "gold_weight_to_be_obtained_for_the_purity"
+  "gold_weight_to_be_obtained_for_the_purity",
+  "voucher_type"
  ],
  "fields": [
   {
@@ -81,12 +82,20 @@
   {
    "fieldname": "column_break_5",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "voucher_type",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Voucher Type",
+   "options": "DocType",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-01-23 16:44:37.586036",
+ "modified": "2023-02-08 16:01:10.713089",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Conversion Chart",

--- a/aumms/aumms/doctype/purity_conversion_tool/purity_conversion_tool.js
+++ b/aumms/aumms/doctype/purity_conversion_tool/purity_conversion_tool.js
@@ -82,6 +82,7 @@ function prepare_conversion_chart(frm) {
 						conversion_charts.purity_to_be_obtained = conversion_chart.purity_to_be_obtained;
 						conversion_charts.gold_weight_to_be_obtained_for_the_purity = conversion_chart.gold_weight;
 						conversion_charts.alloy_weight = conversion_chart.alloy_weight;
+						conversion_charts.voucher_type = conversion_chart.voucher_type;
 					});
 					frm.refresh_field('conversion_charts');
 					frm.trigger('uom')
@@ -125,9 +126,9 @@ let show_total_gw_and_aw = function (frm) {
 			let gw = 'total_gold_weight_to_be_obtained_for_the_purity'
 			frm.set_value(gw, r.message.gw)
 			frm.set_value('total_alloy_weight', r.message.aw)
-			// set description for total GW and AW
-			frm.set_df_property(gw, 'description', ' In ' + frm.doc.uom);
-			frm.set_df_property('total_alloy_weight', 'description', ' In ' + frm.doc.uom);
+			// set label for total GW and AW
+			frm.set_df_property(gw, 'label','Total Gold Weight to be obtained for the purity '+ frm.doc.purity+' In ' + frm.doc.uom);
+			frm.set_df_property('total_alloy_weight', 'label', 'Total Alloy Weight to be obtained for the purity '+ frm.doc.purity+' In ' + frm.doc.uom);
 		}
     })
 }


### PR DESCRIPTION
## Feature description

Updated the purity conversion tool with converted balance qty of a party
changed balance GW and AW label according to uom and purity

## Analysis and design (optional)

![image](https://user-images.githubusercontent.com/105269688/217736737-e41cb702-18a1-439a-8743-61d2ef36931d.png)



## Was this feature tested on the browsers?
  - Chrome
