### PR TITLE
fix: filter for item type with is purity in board rate

### DIFF
--- a/aumms/aumms/doctype/board_rate/board_rate.js
+++ b/aumms/aumms/doctype/board_rate/board_rate.js
@@ -3,18 +3,28 @@
 
 frappe.ui.form.on('Board Rate', {
 	onload(frm) {
-		frm.set_query('uom', function() {
-			return {
-				filters: {
-					is_purity_uom : 1
-				}
-			};
-		});
+		set_filter('uom', {is_purity_uom: 1})
+		set_filter('item_type', {is_purity_item: 1})
 	},
-	validate(frm){
+	validate(frm) {
 		set_title_name(frm)
 	}
 });
-function set_title_name(frm){//set title for board_rate
+function set_title_name(frm) {//set title for board_rate
 	frm.set_value('title', frm.doc.item_type + '-' + frm.doc.purity + '-' + frm.doc.board_rate);
 }
+
+let set_filter = function (field, filters) {
+	/*
+		function to set filter for a specific field
+		args:
+			field: field name
+			filters: set of filters, (eg: {key:value})
+		output: filter applied list for field
+	*/
+	cur_frm.set_query(field, () => {
+	  return {
+		filters: filters
+	  }
+	})
+  }

--- a/aumms/aumms/report/metal_ledger/metal_ledger.js
+++ b/aumms/aumms/report/metal_ledger/metal_ledger.js
@@ -54,7 +54,14 @@ frappe.query_reports['Metal Ledger'] = {
 			'fieldname': 'item_type',
 			'label': __('Item Type'),
 			'fieldtype': 'Link',
-			'options': 'Item Type'
+			'options': 'Item Type',
+			'get_query': function() {
+				return {
+					'filters': {
+						'is_purity_item': 1
+					}
+				}
+			}
 		},
 		{
 			'fieldname': 'batch_no',


### PR DESCRIPTION
## Feature description

filter for item type with is purity in board rate
filter item type with is purity item in metal ledger report

## Analysis and design (optional)

board rate:

![image](https://user-images.githubusercontent.com/105269688/218656710-b3e2e651-2264-4d11-a167-c51ad6b50488.png)

metal ledger report:

![Screenshot from 2023-02-14 12-52-24](https://user-images.githubusercontent.com/105269688/218667485-44c2d9ef-83f0-448a-a95e-e3fc8fbae2d9.png)

## Was this feature tested on the browsers?
  - Chrome
