### PR TITLE
fix:prevented system settings change before setup on migration

### DIFF
--- a/aumms/aumms/utils.py
+++ b/aumms/aumms/utils.py
@@ -236,7 +236,7 @@ def get_party_link_if_exist(party_type, party):
 @frappe.whitelist()
 def increase_precision():
     ''' Method to increase precision on System Settings after migrate '''
-    if frappe.db.exists('System Settings'):
+    if cint(frappe.db.get_single_value("System Settings", "setup_complete") or 0):
         system_settings_doc = frappe.get_doc('System Settings')
         system_settings_doc.float_precision = 6
         system_settings_doc.save()


### PR DESCRIPTION
## Issue description
When migrating before running the setup wizard, an error is returned because no system settings have been produced.

## Analysis and design (optional)
Analyse and attach the design documentation

## Solution description
Added validation to check whether setup wizard is run.

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/138565705/593d8051-d999-4818-a30b-93019fc0c621)

## Areas affected and ensured
Utils

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
