### PR TITLE
fix: Validation changed to before insert only

### DIFF
--- a/aumms/aumms/doctype/aumms_item/aumms_item.js
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.js
@@ -66,6 +66,22 @@ frappe.ui.form.on('AuMMS Item', {
         }
       })
     }
+  },
+  calculate_weight_per_unit(frm){
+    frm.set_value('weight_per_unit', frm.doc.gold_weight + frm.doc.stone_weight);
+    frm.refresh_field('uoms');
+  },
+  gold_weight(frm){
+    frm.trigger('calculate_weight_per_unit');
+  },
+  stone_weight(frm){
+    frm.trigger('calculate_weight_per_unit');
+  },
+  has_stone(frm){
+    if(!frm.doc.has_stone){
+      frm.set_value('stone_weight', 0);
+      frm.set_value('stone_charge', 0);
+    }
   }
 });
 

--- a/aumms/aumms/doctype/aumms_item/aumms_item.json
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.json
@@ -26,14 +26,20 @@
   "description_section",
   "description",
   "inventory_tab",
-  "inventory_settings_section",
-  "weight_per_unit",
+  "weight_details_section",
   "weight_uom",
-  "column_break_jpqvf",
+  "gold_weight",
+  "weight_per_unit",
+  "column_break_mjcg9",
+  "has_stone",
+  "stone_weight",
+  "stone_charge",
+  "inventory_settings_section",
   "is_purchase_item",
   "purchase_uom",
-  "is_sales_item",
+  "column_break_jpqvf",
   "sales_uom",
+  "is_sales_item",
   "unit_of_measure_conversion",
   "uoms",
   "item"
@@ -163,9 +169,11 @@
    "label": "Inventory Settings"
   },
   {
+   "default": "0",
    "fieldname": "weight_per_unit",
    "fieldtype": "Float",
-   "label": "Weight Per Unit"
+   "label": "Net Weight",
+   "read_only": 1
   },
   {
    "fieldname": "weight_uom",
@@ -242,11 +250,49 @@
    "label": "Item",
    "options": "Item",
    "read_only": 1
+  },
+  {
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "default": "0",
+   "depends_on": "has_stone",
+   "fieldname": "stone_weight",
+   "fieldtype": "Float",
+   "label": "Stone Weight",
+   "mandatory_depends_on": "has_stone"
+  },
+  {
+   "default": "0",
+   "fieldname": "gold_weight",
+   "fieldtype": "Float",
+   "label": "Gold Weight",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_mjcg9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_stone",
+   "fieldtype": "Check",
+   "label": "Has Stone"
+  },
+  {
+   "default": "0",
+   "depends_on": "has_stone",
+   "fieldname": "stone_charge",
+   "fieldtype": "Currency",
+   "label": "Stone Charge",
+   "mandatory_depends_on": "has_stone"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-18 15:58:47.541986",
+ "modified": "2023-08-10 13:43:42.899217",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "AuMMS Item",

--- a/aumms/aumms/doctype/aumms_item/aumms_item.py
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.py
@@ -9,8 +9,10 @@ aumms_item_fields = ['item_code', 'item_name', 'item_type', 'stock_uom', 'disabl
 
 class AuMMSItem(Document):
 	def validate(self):
-		self.validate_item_name()
-		self.validate_item_code()
+		''' Method to validate Item name and Item Code '''
+		if self.is_new():
+			self.validate_item_name()
+			self.validate_item_code()
 
 	def after_insert(self):
 		''' Method to create Item from AuMMS Item '''

--- a/aumms/aumms/doctype/aumms_item_group/aumms_item_group.py
+++ b/aumms/aumms/doctype/aumms_item_group/aumms_item_group.py
@@ -59,6 +59,7 @@ class AuMMSItemGroup(NestedSet):
 
 	def validate_item_group_name(self):
 		''' Method to validate AuMMS Item Group Name wrt to Item Group Name '''
-		if self.item_group_name:
-			if frappe.db.exists('Item Group', self.item_group_name):
-				frappe.throw('Item Group `{0}` already exists.'.format(frappe.bold(self.item_group_name)))
+		if self.is_new():
+			if self.item_group_name:
+				if frappe.db.exists('Item Group', self.item_group_name):
+					frappe.throw('Item Group `{0}` already exists.'.format(frappe.bold(self.item_group_name)))


### PR DESCRIPTION
## Feature description
Validation changed to before insert only for following
1. AuMMS Item
2. AuMMS Item Group

Added Stone and Gold Weight and Appplied Calculation in AuMMS Item
![image](https://github.com/efeone/aumms/assets/43608142/f4a02529-68e6-48c2-884a-3755699337d8)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
