### PR TITLE
feat:Created aumms item from design analysis

### DIFF
--- a/aumms/aumms/doctype/aumms_item/aumms_item.py
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.py
@@ -38,7 +38,7 @@ def create_or_update_item(self, item=None):
 	''' Method to create or update Item from AuMMS Item '''
 	item_group = frappe.db.get_value('AuMMS Item Group', self.item_group, 'item_group')
 	if not item:
-		#Case of new Iteam
+		#Case of new Item
 		if not frappe.db.exists('Item', self.name):
 			#Creating new Item object
 			item_doc = frappe.new_doc('Item')

--- a/aumms/aumms/doctype/design_analysis/design_analysis.js
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.js
@@ -116,6 +116,31 @@ frappe.ui.form.on('Design Analysis', {
 
         // Show the dialog
         dia.show();
-        })
+        });
+        // Check if the logged-in user is a supervisor
+        const isSupervisor = frappe.user_roles.includes('Supervisor');
+    if (isSupervisor) {
+        frm.add_custom_button(__('Approve'), () => {
+            const item_code = frm.doc.item_code;
+            const item_group = frm.doc.item_group;
+            const purity = frm.doc.purity;
+
+            frappe.call({
+                method: 'aumms.aumms.doctype.design_analysis.design_analysis.create_aumms_item_from_design_analysis',
+                args: {
+                    item_code: item_code,
+                    item_group: item_group,
+                    purity: purity
+                },
+                callback: (r) => {
+                    if (r.message) {
+                        console.log('AuMMS Item Created:', r.message);
+                    } else {
+                        console.log('Failed to create AuMMS Item');
+                    }
+                }
+            });
+        });
+        }
     }
 });

--- a/aumms/aumms/doctype/design_analysis/design_analysis.json
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "field:item_code",
  "creation": "2023-07-31 15:13:50.941023",
  "default_view": "List",
  "doctype": "DocType",
@@ -11,6 +12,9 @@
   "customer_name",
   "column_break_v9qzp",
   "item",
+  "item_code",
+  "item_group",
+  "purity",
   "section_break_rgobr",
   "column_break_y3jbr",
   "section_break_qqgnh",
@@ -62,7 +66,10 @@
   {
    "fieldname": "item",
    "fieldtype": "Data",
-   "label": "Item"
+   "in_list_view": 1,
+   "label": "Item",
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "section_break_rgobr",
@@ -75,14 +82,38 @@
   {
    "fieldname": "section_break_qqgnh",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Group",
+   "options": "AuMMS Item Group",
+   "reqd": 1
+  },
+  {
+   "fieldname": "purity",
+   "fieldtype": "Link",
+   "label": "Purity",
+   "options": "Purity",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-09 09:30:59.898367",
+ "modified": "2023-08-22 14:44:40.882408",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Design Analysis",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/aumms/aumms/doctype/design_analysis/design_analysis.py
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.py
@@ -6,6 +6,25 @@ from frappe.model.document import Document
 
 class DesignAnalysis(Document):
     pass
+@frappe.whitelist()
+def create_aumms_item_from_design_analysis(item_code, item_group, purity):
+    def set_missing_values(item_code, item_group, purity):
+        pass
+    # Create a new Aumms Item document
+    aumms_item = frappe.get_doc({
+        "doctype": "AuMMS Item",
+        "item_name": item_code,
+        "item_code": item_code,  
+        "item_group": item_group,
+         "purity": purity
+    })
+
+    # Save the Aumms Item document
+    aumms_item.insert()
+
+    frappe.msgprint("AuMMS Item Created: {}".format(aumms_item.name), indicator="green", alert=1)
+
+    return aumms_item.name
 
 @frappe.whitelist()
 def fetch_design_details(parent):


### PR DESCRIPTION
## Feature description
Added a custom button  'Approve' in design analysis Doctype which is visible only for supervisor. By clicking the custom button aumms item is created.



## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/138565705/c3877841-24fe-4be7-ae1a-56dbd11ba857)
![image](https://github.com/efeone/aumms/assets/138565705/b9674bc5-450a-4392-8eb3-66a8611cd867)



## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome

