### PR TITLE
feat: added script to create warehouse for smith users

### DIFF
--- a/aumms/aumms/doc_events/user.py
+++ b/aumms/aumms/doc_events/user.py
@@ -1,0 +1,35 @@
+import frappe
+from frappe.utils import has_common, get_fullname
+
+
+def create_smith_warehouse(doc, method = None):
+    """
+    method to create personal warehouse for a smith user
+    args:
+        doc (class object): object of User
+    """
+    # checking if the user has Smith roles or if the user is administrator
+    user_roles = frappe.get_roles(doc.name)
+    required_roles = ["Smith", "Head of Smith"]
+    if not has_common(user_roles, required_roles) or doc.name == 'Administrator':
+        return
+
+    # generating the warehouse name
+    user_fullname = get_fullname(doc.name)
+    new_warehouse = frappe.new_doc("Warehouse")
+    req_warehouse_name = f"{user_fullname} - Smith"
+
+    # checking if the warehouse already exist
+    warehouse = frappe.db.exists("Warehouse", {"email_id": doc.name, 'parent_warehouse':'All smith Warehouse - EG'})
+    if warehouse:
+        warehouse_doc = frappe.get_doc("Warehouse", warehouse)
+        # renaming the warehouse if the user's full name was changed
+        if not warehouse_doc.warehouse_name == req_warehouse_name:
+            warehouse_doc.warehouse_name = req_warehouse_name
+            warehouse_doc.save()
+    else:
+        # creating a new warehouse
+        new_warehouse.warehouse_name = req_warehouse_name
+        new_warehouse.email_id = doc.name
+        new_warehouse.parent_warehouse = 'All smith Warehouse - EG'
+        new_warehouse.save()

--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -148,6 +148,9 @@ doc_events = {
 	},
 	'Payment Entry':{
 		'on_submit': 'aumms.aumms.doc_events.payment_entry.payment_entry_on_submit'
+	},
+    'User':{
+        'on_update': 'aumms.aumms.doc_events.user.create_smith_warehouse'
 	}
 }
 


### PR DESCRIPTION
## Feature description
Each smith user requires a warehouse to track the items in their possession, for the same a warehouse will be created on user creation

## Analysis and design
Create a warehouse with User's Full Name as Identifier, and email id as foreign key. The warehouse will be under All Smith warehouses

## Solution description
Added a script on update of User to create/update warehouse for users with 'Smith' or 'Head of Smith' role

## Output screenshots
![image](https://github.com/efeone/aumms/assets/91651425/0528b80c-f8f1-4fa4-9a86-fb3cb03f23b8)

## Areas affected and ensured
Hooks
- Doc Events


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
