### PR TITLE
fix: Changed autoname method for AuMMS Item

### DIFF
--- a/aumms/aumms/doctype/design_analysis/design_analysis.js
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.js
@@ -124,13 +124,15 @@ frappe.ui.form.on('Design Analysis', {
             const item_code = frm.doc.item_code;
             const item_group = frm.doc.item_group;
             const purity = frm.doc.purity;
+            const customer_expected_weight = frm.doc.customer_expected_weight;
 
             frappe.call({
                 method: 'aumms.aumms.doctype.design_analysis.design_analysis.create_aumms_item_from_design_analysis',
                 args: {
                     item: item_code,
                     item_group: item_group,
-                    purity: purity
+                    purity: purity,
+                    customer_expected_weight: customer_expected_weight,
                 },
                 callback: (r) => {
                     if (r.message) {

--- a/aumms/aumms/doctype/design_analysis/design_analysis.py
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.py
@@ -27,13 +27,17 @@ def create_bom_function(design_analysis):
         return False
 
 @frappe.whitelist()
-def create_aumms_item_from_design_analysis(item, item_group, purity):
-
+def create_aumms_item_from_design_analysis(customer_expected_weight, item, item_group, purity):
+    #Calculate Item Code to set as docname
+    weight = float(customer_expected_weight)
+    weight = int(weight*1000)
+    weight_with_zero = str(weight).zfill(6)
+    doc_name = item + '-' + weight_with_zero
     # Create a new Aumms Item document
     aumms_item = frappe.get_doc({
         "doctype": "AuMMS Item",
         "item_name": item,
-        "item_code": item,
+        "item_code": doc_name,
         "item_group": item_group,
         "purity": purity
     })


### PR DESCRIPTION
## Feature description
Changed autoname method for AuMMS Item

## Solution description
Changed autoname method for AuMMS Item created from design analysis to be set as 'item code + weight'

## Output screenshots
![Screenshot from 2023-10-31 17-25-33](https://github.com/efeone/aumms/assets/59536246/9875ce43-bce2-4643-9b2a-11082684c2d7)

![Screenshot from 2023-10-31 17-27-24](https://github.com/efeone/aumms/assets/59536246/0264a51d-849b-4145-a884-289b4e842b5d)


## Is there any existing behavior change of other features due to this code change?
AuMMS Item autonaming

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
