### PR TITLE
feat:Add child table for category in smith

### DIFF
--- a/aumms/aumms/doctype/smith/smith.json
+++ b/aumms/aumms/doctype/smith/smith.json
@@ -18,9 +18,9 @@
   "warehouse",
   "department",
   "head_of_smith",
-  "category",
+  "hourly_rate",
   "section_break_9mmii",
-  "hourly_rate"
+  "category"
  ],
  "fields": [
   {
@@ -92,9 +92,9 @@
   },
   {
    "fieldname": "category",
-   "fieldtype": "Link",
+   "fieldtype": "Table",
    "label": "Category",
-   "options": "Smith Category"
+   "options": "Smith Categories"
   },
   {
    "fieldname": "smith_grade",
@@ -105,7 +105,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-26 12:11:32.737297",
+ "modified": "2023-11-02 10:57:11.184968",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Smith",

--- a/aumms/aumms/doctype/smith_categories/smith_categories.json
+++ b/aumms/aumms/doctype/smith_categories/smith_categories.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-11-02 10:54:41.645318",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "smith_category",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "smith_category",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": " Smith Category",
+   "options": "Smith Category"
+  },
+  {
+   "fetch_from": "smith_category.description",
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-11-02 11:01:06.776369",
+ "modified_by": "Administrator",
+ "module": "AuMMS",
+ "name": "Smith Categories",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/aumms/aumms/doctype/smith_categories/smith_categories.py
+++ b/aumms/aumms/doctype/smith_categories/smith_categories.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class SmithCategories(Document):
+	pass

--- a/aumms/aumms/doctype/smith_category/smith_category.json
+++ b/aumms/aumms/doctype/smith_category/smith_category.json
@@ -8,7 +8,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "categories"
+  "categories",
+  "description"
  ],
  "fields": [
   {
@@ -16,11 +17,16 @@
    "fieldtype": "Data",
    "label": "Categories",
    "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-26 11:20:55.759872",
+ "modified": "2023-11-02 11:25:39.363869",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Smith Category",


### PR DESCRIPTION
## Feature description

- Added a child table category to the Smith doctype.
- Add field 'description' in Category.

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/c2814b7f-0a3f-4bdb-8039-75601d434f1b)
![image](https://github.com/efeone/aumms/assets/84179426/4b19752b-6e77-4265-9011-aec1bae18de0)

## Was this feature tested on the browsers?

  - Mozilla Firefox
 
