### PR TITLE
fix: smith warehouse will be created only after setup, warehouse name to be fetched instead of being hardcoded

### DIFF
--- a/aumms/setup.py
+++ b/aumms/setup.py
@@ -58,7 +58,7 @@ def create_all_smith_warehouse():
     if not frappe.db.exists('Warehouse', {'warehouse_name': 'All Smith Warehouse'}):
         warehouse_doc = frappe.new_doc('Warehouse')
         warehouse_doc.company = default_company
-        warehouse_doc.warehouse_name = 'All smith Warehouse'
+        warehouse_doc.warehouse_name = 'All Smith Warehouse'
         warehouse_doc.parent_warehouse = warehouse
         warehouse_doc.is_group = 1
         warehouse_doc.insert(ignore_permissions = True)


### PR DESCRIPTION
## Issue description
Setup not completing

## Analysis
The warehouse name of All Smith warehouse was hardcoded

## Solution description
- made it so that the warehouse name will be fetched
- fixed an issue with capitallization

## Output screenshots
![image](https://github.com/efeone/aumms/assets/91651425/13f2f795-e746-4b32-bdf4-9f97d7648236)


## Areas affected and ensured
Doc events
- User
- Setup

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome 
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
