### PR TITLE
Update the status of linked design request according to design analysis

### DIFF
--- a/aumms/aumms/doctype/design_analysis/design_analysis.js
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.js
@@ -88,24 +88,25 @@ let create_bom_button = function(frm){
     }
   }
 
-let request_for_verification = function(frm){
-  if(frm.doc.dr_required_check){
-    frappe.call({
-      method: 'aumms.aumms.doctype.design_analysis.design_analysis.create_design_request',
-      args: {
-        design_analysis: frm.doc.name
-      },
-      callback: (r) => {
-                frm.reload_doc()
-             },
-    })
-  }
-  else{
-    frm.scroll_to_field('verified_item');
-    if(frm.doc.verified_item.length<1){
-      frappe.msgprint("Please fill the verified item table");
+let request_for_verification = function (frm) {
+    if (frm.doc.dr_required_check) {
+        frappe.call({
+            method: 'aumms.aumms.doctype.design_analysis.design_analysis.create_design_request',
+            args: {
+                design_analysis: frm.doc.name
+            },
+            callback: (r) => {
+                frm.set_value("status", "Request For Verification");
+                frm.save();
+            },
+        })
     }
-  }
+    else {
+        frm.scroll_to_field('verified_item');
+        if (frm.doc.verified_item.length < 1) {
+            frappe.msgprint("Please fill the verified item table");
+        }
+    }
 }
 
 let request_for_approval = function(frm){
@@ -166,8 +167,10 @@ let make_request_for_approval = function (frm) {
                     },
                     freeze: true,
                     callback: (r) => {
-                        frm.reload_doc();
-                        d.hide()
+                        frm.set_value("assigned_person", assign_to)
+                        frm.set_value("status", "Request For Approval");
+                        frm.save();
+                        d.hide();
                     }
                 });
             }
@@ -198,7 +201,7 @@ let approve_design_analysis = function(frm) {
                     callback: (r) => {
                         if (r.message) {
                             frm.set_value('aumms_item', r.message);
-                            frm.set_value("status","Approved")
+                            frm.set_value("status","Approved");
                             frm.save();
                             console.log('AuMMS Item Created:', r.message);
 
@@ -309,7 +312,9 @@ function create_bom(frm) {
                     },
                     freeze: true,
                     callback: (r) => {
-                        frm.reload_doc();
+                        frm.set_value("bom_created", 1);
+                        frm.set_value("status", "BOM Created");
+                        frm.save();
                         bom_dia.hide();
                     }
                 });

--- a/aumms/aumms/doctype/design_analysis/design_analysis.py
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.py
@@ -10,6 +10,11 @@ class DesignAnalysis(Document):
     def autoname(self):
           if self.customer_name:
                self.name = self.customer_name + '-' + self.item_code + '-' + frappe.utils.today()
+    def on_update(self):
+        design_request_doc = frappe.get_doc("Design Request", self.design_request)
+        design_request_doc.status = self.status
+        design_request_doc.save()
+        frappe.db.commit()
 
 @frappe.whitelist()
 def create_bom_function(doctype, docname,assign_to):

--- a/aumms/aumms/doctype/design_analysis/design_analysis.py
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.py
@@ -29,14 +29,12 @@ def create_bom_function(doctype, docname,assign_to):
              bom_row.qty = row.quantity
         bom.flags.ignore_mandatory = True
         bom.save(ignore_permissions=True)
-        frappe.db.set_value(doctype, docname, 'bom_created', 1)
         assign_to_list = [assign_to]
         add_assign({
                 "assign_to": assign_to_list,
                 "doctype": bom.doctype,
                 "name": bom.name
             })
-        frappe.db.set_value(doctype, docname, 'status','BOM Created')
         frappe.db.commit()
         frappe.msgprint("BOM Created", indicator="green", alert=1)
         #Send system notification and email to assignee
@@ -124,9 +122,6 @@ def create_design_request(design_analysis):
                 design_request.delivery_date = frappe.utils.today()
                 design_request.flags.ignore_mandatory = True
                 design_request.save(ignore_permissions=True)
-            if doc.status == 'Draft':
-                frappe.db.set_value("Design Analysis", design_analysis, 'status', 'Request For Verification')
-                doc.reload()
                 frappe.msgprint("Design Request Created for the material {}".format(design_request.design_title), indicator="green", alert=1)
 
 @frappe.whitelist()
@@ -137,6 +132,3 @@ def assign_design_analysis(doctype, docname, assign_to):
     "doctype": doctype,
     "name": docname
     })
-    frappe.db.set_value(doctype, docname, 'assigned_person', assign_to)
-    frappe.db.set_value(doctype, docname, 'status','Request For Approval')
-    frappe.db.commit()

--- a/aumms/aumms/doctype/design_request/design_request.json
+++ b/aumms/aumms/doctype/design_request/design_request.json
@@ -10,6 +10,7 @@
   "customer",
   "customer_name",
   "mobile_no",
+  "status",
   "column_break_ey72q",
   "design_title",
   "expected_weight",
@@ -21,8 +22,7 @@
   "tab_break_gwdao",
   "attachment",
   "image",
-  "amended_from",
-  "status"
+  "amended_from"
  ],
  "fields": [
   {
@@ -128,16 +128,19 @@
    "label": "Expected Weight"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "status",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Status"
+   "label": "Status",
+   "options": "Draft\nRequest For Verification\nRequest For Approval\nApproved\nHold\nRejected\nBOM Created\nWorkorder Created",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-11-07 15:47:10.811032",
+ "modified": "2023-11-09 11:21:15.789726",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Design Request",


### PR DESCRIPTION
## Feature description
The status of design request document linked to the design analysis document would be updated according to status of the design analysis document.

## Output screenshots
[Screencast from 09-11-23 04:20:13 PM IST.webm](https://github.com/efeone/aumms/assets/59536246/2044d430-2d66-461e-8500-d633f427a68b)

## Areas affected and ensured
Status field of design request document

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox