### PR TITLE
feat: customisation in Smith DocType

### DIFF
--- a/aumms/aumms/doctype/smith/smith.js
+++ b/aumms/aumms/doctype/smith/smith.js
@@ -2,11 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Smith', {
+	refresh:function(frm) {
+		set_head_of_smith_filter_query(frm)
+	},
 	smith_type: function(frm) {
 		reset_smith_fields(frm)
+		set_smith_reference_filter_query(frm)
 	},
 	employee: function(frm) {
 		set_smith_full_name(frm)
+		set_department(frm)
 	},
 	supplier:  function(frm) {
 		set_smith_full_name(frm)
@@ -37,5 +42,42 @@ function reset_smith_fields(frm) {
 	frm.set_value('smith_name', '')
 	frm.set_value('employee', '')
 	frm.set_value('supplier', '')
+	frm.set_value('department', '')
+	frm.set_df_property('department', 'read_only', 0)
 	frm.refresh_fields()
+}
+
+function set_head_of_smith_filter_query(frm) {
+	// set filter for head of smith field, only head of smith employees will be listed
+	frm.set_query('head_of_smith', () => {
+		return {
+			query: 'aumms.aumms.doctype.smith.smith.head_of_smith_filter_query'
+		}
+	})
+}
+
+function set_smith_reference_filter_query(frm) {
+	// set filter for employee and supplier fields, exclude those with Smith already created
+	let fieldname = 'employee'
+	if (frm.doc.smith_type == 'External') {
+		fieldname = 'supplier'
+	}
+	frm.set_query(fieldname, () => {
+		return {
+			query: 'aumms.aumms.doctype.smith.smith.smith_reference_filter_query'
+		}
+	})
+}
+
+function set_department(frm) {
+	// fetch department and set the field as read only if smith type is internal and employee is selected
+	if (frm.doc. employee){
+		frappe.db.get_value('Employee', frm.doc.employee, 'department')
+			.then(r => {
+				let department = r.message.department
+				frm.set_value('department', department)
+				frm.set_df_property('department', 'read_only', 1)
+				frm.refresh_fields()
+			})
+	}
 }

--- a/aumms/aumms/doctype/smith/smith.json
+++ b/aumms/aumms/doctype/smith/smith.json
@@ -55,7 +55,8 @@
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "label": "Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "read_only": 1
   },
   {
    "fieldname": "department",
@@ -112,7 +113,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-09 12:17:19.136645",
+ "modified": "2023-11-10 13:12:57.067492",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Smith",

--- a/aumms/aumms/doctype/smith/smith.py
+++ b/aumms/aumms/doctype/smith/smith.py
@@ -50,3 +50,38 @@ def get_all_smith_warehouse():
 		return all_smith_warehouse
 	else:
 		frappe.throw(_('All Smith Warehouse not found, Please contact System Manager'))
+
+@frappe.whitelist()
+def head_of_smith_filter_query(doctype, txt, searchfield, start, page_len, filters):
+	'''
+		Query for Head of Smith field in Smith DocType
+	'''
+	return frappe.db.sql('''
+		SELECT
+			employee
+		FROM
+			tabSmith
+		WHERE
+			is_head_of_smith = 1
+	''')
+
+@frappe.whitelist()
+def smith_reference_filter_query(doctype, txt, searchfield, start, page_len, filters):
+	'''
+		Query for Employee and Supplier fields in Smith DocType
+	'''
+	return frappe.db.sql('''
+		SELECT
+			name
+		FROM
+			{tab_of_doctype}
+		WHERE
+			name
+		NOT IN
+			(
+				SELECT
+					{doctype}
+				FROM
+					tabSmith
+			)
+	'''.format(tab_of_doctype = f'tab{doctype}', doctype = doctype.lower()))


### PR DESCRIPTION
## Feature description
- Set warehouse as read only
- Added filters for Employee, Supplier and Head of Smith fields
- Added script to fetch department if Smith is an Employee

## Output screenshots
![image](https://github.com/efeone/aumms/assets/91651425/5c2cdf8d-be16-4740-8bfe-13c33b74ae66)

## Areas affected and ensured
DocType
- Smith

## Is there any existing behavior change of other features due to this code change?
Yes, Department will become read only if the smith is an employee

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
