### PR TITLE
feat: Create stock entry on creating BOM

### DIFF
--- a/aumms/aumms/doctype/aumms_settings/aumms_settings.json
+++ b/aumms/aumms/doctype/aumms_settings/aumms_settings.json
@@ -11,7 +11,8 @@
   "metal_ledger_uom",
   "old_gold_item",
   "column_break_2",
-  "metal_ledger_purity"
+  "metal_ledger_purity",
+  "default_warehouse"
  ],
  "fields": [
   {
@@ -40,12 +41,18 @@
    "fieldtype": "Link",
    "label": "Old Gold Item",
    "options": "AuMMS Item"
+  },
+  {
+   "fieldname": "default_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Warehouse",
+   "options": "Warehouse"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-08-04 10:11:36.992374",
+ "modified": "2023-11-15 12:10:31.006443",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "AuMMS Settings",

--- a/aumms/aumms/doctype/design_analysis/design_analysis.py
+++ b/aumms/aumms/doctype/design_analysis/design_analysis.py
@@ -35,8 +35,21 @@ def create_bom_function(doctype, docname,assign_to):
                 "doctype": bom.doctype,
                 "name": bom.name
             })
+        s_warehouse = frappe.get_single("AuMMS Settings").get("default_warehouse")
+        t_warehouse = frappe.get_value("Smith", {"email" : assign_to}, "warehouse")
+        stock_entry = frappe.new_doc("Stock Entry")
+        stock_entry.stock_entry_type = "Material Transfer"
+        for row in doc.verified_item:
+            items_row = stock_entry.append('items')
+            items_row.item_code = row.item
+            items_row.s_warehouse = s_warehouse
+            items_row.t_warehouse = t_warehouse
+            items_row.qty = row.quantity
+            items_row.allow_zero_valuation_rate = 1
+        stock_entry.submit()
         frappe.db.commit()
         frappe.msgprint("BOM Created", indicator="green", alert=1)
+        frappe.msgprint("Stock Entry Created", indicator="green", alert=1)
         #Send system notification and email to assignee
         subject = "New BOM request received"
         content = "You've been assigned a new BOM for work order creation. Please review it at your earliest convenience."


### PR DESCRIPTION
## Feature description
Create a stock entry on creating BOM from design analysis

## Solution description
Create a stock entry on creating BOM from design analysis with source warehouse as Store and target warehouse as Head of Smith's warehouse who is assigned the BOM.

## Output screenshots
![Screenshot from 2023-11-15 17-36-04](https://github.com/efeone/aumms/assets/59536246/e21e7c27-a0ae-445e-bca5-a77e2ab810d4)
![Screenshot from 2023-11-15 17-36-16](https://github.com/efeone/aumms/assets/59536246/92be68ae-f4af-4d18-8a70-7fbd6fe9b276)


## Areas affected and ensured
Stock Entry, Stock Ledger

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
