### PR TITLE
fix: Changed parent warehouse for all smiiths to All Smith Warehouse

### DIFF
--- a/aumms/aumms/doctype/smith/smith.py
+++ b/aumms/aumms/doctype/smith/smith.py
@@ -26,18 +26,8 @@ class Smith(Document):
 
 			# creating a new warehouse
 			new_warehouse.warehouse_name = req_warehouse_name
-			if self.is_head_of_smith:
-				new_warehouse.is_group = 1
-				new_warehouse.parent_warehouse = get_all_smith_warehouse()
-			else:
-				head_of_smith = frappe.db.exists('Smith', {'employee':self.head_of_smith})
-				if not head_of_smith:
-					frappe.throw(_(f'Smith not found for {self.head_of_smith}'))
-				head_of_smith_warehouse = frappe.db.get_value('Smith', head_of_smith, 'warehouse')
-				if not head_of_smith_warehouse:
-					frappe.throw(_(f'No Warehouse found for Head of Smith {head_of_smith}'))
-				new_warehouse.parent_warehouse = head_of_smith_warehouse
-
+			new_warehouse.is_group = 0
+			new_warehouse.parent_warehouse = get_all_smith_warehouse()
 			new_warehouse.save(ignore_permissions=True)
 			self.warehouse = new_warehouse.name
 


### PR DESCRIPTION
## Feature description
Changed parent warehouse for all smiths to All Smith Warehouse

## Solution description
Parent warehouse for smiths were head of smith's warehouse. It has now been changed to All Smith Warehouse

## Output screenshots
![image](https://github.com/efeone/aumms/assets/59536246/c55935df-9af6-4e8c-86a8-d580c114a545)

## Areas affected and ensured
Warehouse of Smiths

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
