### PR TITLE
fix: Added fixes to employee, DR, and smith

### DIFF
--- a/aumms/aumms/custom/employee.json
+++ b/aumms/aumms/custom/employee.json
@@ -1,0 +1,32 @@
+{
+ "custom_fields": [],
+ "custom_perms": [],
+ "doctype": "Employee",
+ "links": [],
+ "property_setters": [
+  {
+   "_assign": null,
+   "_comments": null,
+   "_liked_by": null,
+   "_user_tags": null,
+   "creation": "2023-11-16 12:51:51.053392",
+   "default_value": null,
+   "doc_type": "Employee",
+   "docstatus": 0,
+   "doctype_or_field": "DocField",
+   "field_name": "company_email",
+   "idx": 0,
+   "is_system_generated": 0,
+   "modified": "2023-11-16 12:51:51.053392",
+   "modified_by": "Administrator",
+   "module": null,
+   "name": "Employee-company_email-reqd",
+   "owner": "Administrator",
+   "property": "reqd",
+   "property_type": "Check",
+   "row_name": null,
+   "value": "1"
+  }
+ ],
+ "sync_on_migrate": 1
+}

--- a/aumms/aumms/doctype/design_request/design_request.js
+++ b/aumms/aumms/doctype/design_request/design_request.js
@@ -19,7 +19,7 @@ frappe.ui.form.on('Design Request', {
 		}
 	},
 	refresh: function(frm) {
-        if(!frm.doc.assigned_person && !frm.is_new()) {
+        if(!frm.doc.assigned_person && !frm.is_new() && frm.doc.docstatus == 1) {
             frm.add_custom_button(__('Assign'), () => {
                 let d = new frappe.ui.Dialog({
                     title: __('Assign Design Request'),

--- a/aumms/aumms/doctype/smith/smith.json
+++ b/aumms/aumms/doctype/smith/smith.json
@@ -118,12 +118,13 @@
    "label": "Email",
    "mandatory_depends_on": "eval:doc.is_head_of_smith",
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-14 12:11:41.367067",
+ "modified": "2023-11-16 12:48:51.743227",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Smith",
@@ -143,7 +144,6 @@
    "write": 1
   }
  ],
- "search_fields": "smith_name",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
## Feature description

-  Changed company email field in employee to mandatory
- Changed Assign button in design request to show only after the document is submitted
- Changed email field in Smith to unique

## Solution description

- Company email in employee is required for user creation on creating smith.

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox