### PR TITLE
feat:Create Item, Purchase Receipt and Metal Ledger while Submitting the Purchase Tool

### DIFF
--- a/aumms/aumms/doctype/purchase_item_details/purchase_item_details.json
+++ b/aumms/aumms/doctype/purchase_item_details/purchase_item_details.json
@@ -3,29 +3,26 @@
  "allow_rename": 1,
  "creation": "2024-02-12 23:46:19.937061",
  "doctype": "DocType",
+ "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "item_details_column",
-  "item_name",
+  "item_code",
   "gold_weight",
   "net_weight",
+  "uom",
   "column_break_juco",
   "stone",
   "stone_weight",
   "stone_charge",
-  "amount"
+  "amount",
+  "purity"
  ],
  "fields": [
   {
    "fieldname": "item_details_column",
    "fieldtype": "Column Break",
    "label": "Item Details "
-  },
-  {
-   "fieldname": "item_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Item Code"
   },
   {
    "fieldname": "gold_weight",
@@ -54,7 +51,8 @@
    "fieldname": "stone",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Stone"
+   "label": "Stone",
+   "read_only": 1
   },
   {
    "fieldname": "stone_weight",
@@ -68,12 +66,32 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Stone Charge"
+  },
+  {
+   "fieldname": "purity",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Purity",
+   "options": "Purity"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Item Code"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-16 12:40:10.378507",
+ "modified": "2024-02-16 15:04:13.555094",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Purchase Item Details",

--- a/aumms/aumms/doctype/purchase_tool/purchase_tool.py
+++ b/aumms/aumms/doctype/purchase_tool/purchase_tool.py
@@ -1,9 +1,62 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
-
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.model.naming import make_autoname
+from frappe.model.mapper import get_mapped_doc
 
 class PurchaseTool(Document):
-	pass
+
+    def before_submit(self):
+        self.create_item()
+
+    def on_submit(self):
+        self.create_purchase_receipt()
+
+    def create_item(self):
+        for item_detail in self.get("item_details"):
+            aumms_item = frappe.new_doc('AuMMS Item')
+            aumms_item.item_code = item_detail.item_code
+            aumms_item.item_name = item_detail.item_code
+            aumms_item.purity = item_detail.purity
+            aumms_item.item_group = self.item_group
+            aumms_item.item_type = self.item_type
+            aumms_item.weight_per_unit = item_detail.net_weight
+            aumms_item.weight_uom = item_detail.uom
+            aumms_item.has_stone = self.has_stone
+            # If has_stone is checked, fetch stone details from item_detail
+            if self.has_stone:
+                aumms_item.append('stone_details', {
+                    'stone_weight': item_detail.stone_weight,
+                    'stone_charge': item_detail.stone_charge,
+                    'item_name': self.stone,
+                    'item_type': self.stone,
+                })
+            frappe.msgprint('AuMMS Item Created.')
+            aumms_item.insert(ignore_permissions=True)
+
+    def create_purchase_receipt(self):
+        purchase_receipt = frappe.new_doc('Purchase Receipt')
+        purchase_receipt.supplier = self.supplier,
+        purchase_receipt.keep_metal_ledger = 1
+
+        for item_detail in self.get("item_details"):
+            # Fetch details from AuMMS Item's item_details
+            aumms_item = frappe.get_doc('AuMMS Item', item_detail.item_code)
+
+            purchase_receipt.append('items', {
+                'item_code': aumms_item.item_code,
+                'item_name': aumms_item.item_name,
+                'qty': item_detail.net_weight,
+                'uom': item_detail.uom,
+                'stock_uom': aumms_item.weight_uom,
+                'conversion_factor': aumms_item.weight_per_unit / item_detail.net_weight,
+                'base_rate': self.board_rate,
+            })
+
+            # Save and submit the Purchase Receipt
+            purchase_receipt.insert(ignore_permissions=True)
+            purchase_receipt.save(ignore_permissions=True)
+            purchase_receipt.submit()
+
+            frappe.msgprint('Purchase Receipt created and submitted successfully.')


### PR DESCRIPTION
## Feature description
Create Item, Purchase Receipt and Metal Ledger while Submitting the Purchase Tool

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/ff6f1cb6-ea49-4963-9af6-96307629f512)
![image](https://github.com/efeone/aumms/assets/84179426/b70e85a3-2108-4ab2-b77b-24a7a5b52498)
![image](https://github.com/efeone/aumms/assets/84179426/6ee6b521-7c51-40b1-8617-fa7150db396b)
![image](https://github.com/efeone/aumms/assets/84179426/8baccd13-a733-4b04-90c5-f94c9983ec64)
![image](https://github.com/efeone/aumms/assets/84179426/6c4d25ff-02aa-4038-a53c-ffbf82010d16)

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
