### PR TITLE
Added Multiple Stone Details on Aumms Item Created While submitting Jewellery Receipt

### DIFF
--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -12,6 +12,7 @@
   "gold_weight",
   "stone_weight",
   "net_weight",
+  "individual_stone_weight",
   "column_break_juco",
   "stone",
   "unit_stone_charge",
@@ -120,12 +121,18 @@
    "fieldname": "unit_stone_charge",
    "fieldtype": "Int",
    "label": "Unit Stone Charge"
+  },
+  {
+   "fieldname": "individual_stone_weight",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Individual Stone Weight"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-01 12:33:21.126025",
+ "modified": "2024-03-01 13:18:13.905918",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Item Receipt",

--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -112,7 +112,8 @@
   {
    "fieldname": "making_chargein_percentage",
    "fieldtype": "Percent",
-   "label": "Making Charge(In Percentage)"
+   "label": "Making Charge(In Percentage)",
+   "reqd": 1
   },
   {
    "default": "3000",
@@ -124,7 +125,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-29 14:50:48.946413",
+ "modified": "2024-03-01 12:33:21.126025",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Item Receipt",

--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -60,7 +60,6 @@
   {
    "fieldname": "net_weight",
    "fieldtype": "Float",
-   "in_list_view": 1,
    "label": "Net Weight",
    "read_only": 1
   },
@@ -125,7 +124,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-26 14:46:45.162826",
+ "modified": "2024-02-29 14:50:48.946413",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Item Receipt",

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -106,18 +106,23 @@ let create_item_details = function(frm) {
     primary_action: function(values) {
       console.log(values);
       let stone_names = "";
-      let stone_charge = 0
+      let stone_charge = 0;
+      let stone_weight = "";
       for (let i = 0; i < values.stone_details.length; i++) {
           stone_names += values.stone_details[i].stone;
+          stone_weight += values.stone_details[i].stone_weight;
+
           if (i < values.stone_details.length - 1) {
-              stone_names += " - ";
-          }
+              stone_names += " , ";
+              stone_weight += " , ";
+          };
       }
       var child = frm.add_child('item_details');
       child.uom = values.uom;
       child.gold_weight = values.gold_weight;
       child.making_chargein_percentage = values.making_charge_in_percentage;
       child.stone = stone_names;
+      child.individual_stone_weight = stone_weight;
       child.stone_weight = values.total_stone_weight;
       child.unit_stone_charge = values.unit_stone_charge;
       for (let i = 0; i < values.stone_details.length; i++) {

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -63,10 +63,6 @@ let create_item_details = function(frm) {
         label: 'Making Charge In Percentage',
         fieldname: 'making_charge_in_percentage',
         fieldtype: 'Percent',
-        onchange: function() {
-          // Calculate making charge when making_charge_in_percentage changes
-          calculate_making_charge();
-        }
       },
       {
         label: 'Has Stone',
@@ -112,50 +108,42 @@ let create_item_details = function(frm) {
     ],
     primary_action_label: 'Submit',
     primary_action: function(values) {
-        console.log(values);
-        var StoneDetails = values.stone_details;
-        for (var i = 0; i < StoneDetails.length; i++) {
-            var child = frm.add_child('item_details');
-            child.uom = values.uom;
-            child.gold_weight = values.gold_weight;
-            child.making_chargein_percentage = values.making_charge_in_percentage;
-            child.has_stone = values.has_stone;
-            child.stone = StoneDetails[i].stone;
-            child.stone_weight = StoneDetails[i].stone_weight;
-            child.unit_stone_charge = values.unit_stone_charge; // Include unit_stone_charge
+      console.log(values);
+      let stone_names = "";
+      let stone_charge = 0
+      if (values.has_stone) {
+          // Concatenate the names of all stones
+          for (let i = 0; i < values.stone_details.length; i++) {
+              stone_names += values.stone_details[i].stone;
+              if (i < values.stone_details.length - 1) {
+                  stone_names += " - ";
+              }
+          }
+      }
+      var child = frm.add_child('item_details');
+      child.uom = values.uom;
+      child.gold_weight = values.gold_weight;
+      child.making_chargein_percentage = values.making_charge_in_percentage;
+      child.has_stone = values.has_stone;
+      child.stone = stone_names;
+      child.stone_weight = values.total_stone_weight;
+      child.unit_stone_charge = values.unit_stone_charge;
+      if (values.has_stone) {
+          for (let i = 0; i < values.stone_details.length; i++) {
+              let stone_charge = values.unit_stone_charge * values.total_stone_weight;
+              frappe.model.set_value(child.doctype, child.name, 'stone_charge', stone_charge);
+          }
+          let amount_without_making_charge = (values.gold_weight * frm.doc.board_rate) + stone_charge;
+          frappe.model.set_value(child.doctype, child.name, 'amount_without_making_charge', amount_without_making_charge);
+          let making_charge = amount_without_making_charge * (child.making_chargein_percentage / 100);
+          frappe.model.set_value(child.doctype, child.name, 'making_charge', making_charge);
+      }
 
-            // Calculate stone charge for each stone detail
-            if (values.has_stone) {
-                let stone_charge = StoneDetails[i].stone_weight * values.unit_stone_charge;
-                frappe.model.set_value(child.doctype, child.name, 'stone_charge', stone_charge);
-
-                // Calculate amount without making charge
-                let amount_without_making_charge = (values.gold_weight * frm.doc.board_rate) + stone_charge;
-                frappe.model.set_value(child.doctype, child.name, 'amount_without_making_charge', amount_without_making_charge);
-            }
-             calculate_making_charge(child);
-        }
-
-        // Refresh the child table field to reflect the changes
-        refresh_field("item_details");
-
-        // Hide the dialogue box
-        d.hide();
-    }
-
-  });
-
-  function calculate_making_charge(child) {
-    let making_charge_in_percentage = child.making_chargein_percentage;
-    if (making_charge_in_percentage) {
-      let gold_weight = child.gold_weight || 0;
-      let amount_without_making_charge = child.amount_without_making_charge || 0;
-      let making_charge = amount_without_making_charge * (child.making_chargein_percentage / 100);
-      frappe.model.set_value(child.doctype, child.name, 'making_charge', making_charge);
-    }
+      refresh_field("item_details");
+      d.hide();
   }
-
-  function calculate_total_stone_weight() {
+  });
+function calculate_total_stone_weight() {
     let total_weight = 0;
     let stone_details = d.get_value('stone_details');
     if (stone_details && stone_details.length > 0) {
@@ -212,14 +200,22 @@ frappe.ui.form.on("Jewellery Item Receipt", {
         if (frm.doc.has_stone) {
             let net_weight = d.gold_weight + d.stone_weight;
             frappe.model.set_value(cdt, cdn, 'net_weight', net_weight);
-            // let stone_charge = d.unit_stone_charge * d.stone_weight;
-            // frappe.model.set_value(cdt, cdn, 'stone_charge', stone_charge)
         }
-        if (d.making_charge) {
-                let amount = d.amount_without_making_charge + d.making_charge
-                frappe.model.set_value(cdt, cdn, 'amount', amount);
-            }
-        frm.fields_dict.item_details.grid.toggle_enable('has_stone', frm.doc.has_stone);frm.fields_dict.item_details.grid.toggle_enable('has_stone', frm.doc.has_stone);
+    },
+    stone_weight: function(frm, cdt, cdn){
+      let d = locals[cdt][cdn];
+      if (frm.doc.has_stone){
+        let net_weight = d.gold_weight + d.stone_weight;
+        frappe.model.set_value(cdt, cdn, 'net_weight', net_weight);
+        let stone_charge = d.unit_stone_charge * d.stone_weight;
+        frappe.model.set_value(cdt, cdn, 'stone_charge', stone_charge);
+      }
+    },
+    making_charge : function(frm, cdt, cdn){
+      if (d.making_charge) {
+        let amount = d.amount_without_making_charge + d.making_charge
+        frappe.model.set_value(cdt, cdn, 'amount', amount);
+      }frm.fields_dict.item_details.grid.toggle_enable('has_stone', frm.doc.has_stone);frm.fields_dict.item_details.grid.toggle_enable('has_stone', frm.doc.has_stone);
     },
     gold_weight: function(frm, cdt, cdn) {
       let d = locals[cdt][cdn];
@@ -233,7 +229,7 @@ frappe.ui.form.on("Jewellery Item Receipt", {
     making_chargein_percentage: function(frm, cdt, cdn) {
       let d = locals[cdt][cdn];
       if (d.amount_without_making_charge && d.making_chargein_percentage) {
-          let making_charge = d.amount_without_making_charge * (d.making_chargein_percentage / 100); // Calculate the specified percentage of amount_without_making_charge
+          let making_charge = d.amount_without_making_charge * (d.making_chargein_percentage / 100);
           frappe.model.set_value(cdt, cdn, 'making_charge', making_charge);
       }
     },

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
@@ -17,9 +17,10 @@
   "board_rate",
   "date",
   "has_stone",
+  "single_stone",
   "stone",
-  "section_break_vxux",
   "create_item",
+  "section_break_vxux",
   "item_details",
   "amended_from"
  ],
@@ -32,7 +33,8 @@
    "fieldname": "item_category",
    "fieldtype": "Link",
    "label": "Item Category",
-   "options": "Item Category"
+   "options": "Item Category",
+   "reqd": 1
   },
   {
    "fieldname": "item_type",
@@ -83,10 +85,11 @@
    "label": "Has Stone"
   },
   {
-   "depends_on": "eval:doc.has_stone == 1",
+   "depends_on": "eval:doc.single_stone",
    "fieldname": "stone",
    "fieldtype": "Link",
    "label": "Stone",
+   "mandatory_depends_on": "eval:doc.single_stone",
    "options": "AuMMS Item"
   },
   {
@@ -123,16 +126,23 @@
    "label": "Fixed Charge"
   },
   {
-   "depends_on": "eval:doc.has_stone",
+   "depends_on": "eval:doc.has_stone && doc.single_stone != 1",
    "fieldname": "create_item",
    "fieldtype": "Button",
    "label": "Create Item"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.has_stone ==1",
+   "fieldname": "single_stone",
+   "fieldtype": "Check",
+   "label": "Single Stone"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-02-29 11:53:41.803877",
+ "modified": "2024-03-01 12:32:02.236025",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Receipt",

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
@@ -30,9 +30,14 @@ class JewelleryReceipt(Document):
 
     def on_submit(self):
         self.create_purchase_receipt()
+        self.make_form_read_only(['aumms_item', 'purchase_receipt', 'metal_ledger'])
 
     def validate_date(self):
         self.calculate_item_details()
+
+    def make_form_read_only(self, fields):
+        for field in fields:
+            self.set(field, 'read_only', 1)
 
     def create_item(self):
         for item_detail in self.get("item_details"):
@@ -48,12 +53,28 @@ class JewelleryReceipt(Document):
             aumms_item.gold_weight = item_detail.gold_weight
             # If has_stone is checked, fetch stone details from item_detail
             if self.has_stone:
-                aumms_item.append('stone_details', {
-                    'stone_weight': item_detail.stone_weight,
-                    'stone_charge': item_detail.stone_charge,
-                    'item_name': item_detail.stone,
-                    'item_type': item_detail.stone,
-                })
+                if self.single_stone:
+                    stones = item_detail.stone.split(',')
+                    for stone in stones:
+                        aumms_item.append('stone_details', {
+                            'stone_weight': item_detail.stone_weight,
+                            'stone_charge': item_detail.stone_charge,
+                            'item_name': stone,
+                            'stone_type': stone,
+                        })
+
+                stones = item_detail.stone.split(',')
+                individual_stone_weight = item_detail.individual_stone_weight
+                if individual_stone_weight:
+                    stone_weights = individual_stone_weight.split(',')
+                    for stone, weight in zip(stones, stone_weights):
+                        aumms_item.append('stone_details', {
+                            'stone_weight': float(weight),
+                            'stone_charge': item_detail.unit_stone_charge * float(weight),
+                            'item_name': stone,
+                            'stone_type': stone,
+                        })
+
             aumms_item.insert(ignore_permissions=True)
             frappe.msgprint('AuMMS Item Created.', indicator="green", alert=1)
 

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
-import json
 import frappe
-from frappe import _
-from frappe.utils import flt
 from frappe.model import meta
 from frappe.utils import today
 from frappe.model.document import Document
@@ -54,8 +51,8 @@ class JewelleryReceipt(Document):
                 aumms_item.append('stone_details', {
                     'stone_weight': item_detail.stone_weight,
                     'stone_charge': item_detail.stone_charge,
-                    'item_name': self.stone,
-                    'item_type': self.stone,
+                    'item_name': item_detail.stone,
+                    'item_type': item_detail.stone,
                 })
             aumms_item.insert(ignore_permissions=True)
             frappe.msgprint('AuMMS Item Created.', indicator="green", alert=1)


### PR DESCRIPTION
## Feature description
Added Multiple Stone Details on Aumms Item Created While submitting Jewellery Receipt

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/d4468889-18bc-4dbd-a091-5a5a34636cec)
![image](https://github.com/efeone/aumms/assets/84179426/b755e015-8957-4fb4-abce-6da8b42018da)
![image](https://github.com/efeone/aumms/assets/84179426/3141b632-bb48-4fba-9393-bade67ca1d5d)
![image](https://github.com/efeone/aumms/assets/84179426/7735cd00-08b1-4de3-bd89-d59caf27d580)
![image](https://github.com/efeone/aumms/assets/84179426/a27d8a73-18b4-498b-98dd-9492b04df4fc)


## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  
