### PR TITLE
fix : Set Aumms item doctype as read only after saving

### DIFF
--- a/aumms/aumms/doctype/aumms_item/aumms_item.js
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.js
@@ -98,6 +98,9 @@ frappe.ui.form.on('AuMMS Item', {
   },
   refresh(frm){
     frm.trigger('triger_checkbox_display');
+    if (!frm.is_new()){
+      frm.disable_form();
+    }
   }
 });
 

--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -55,12 +55,12 @@
    "depends_on": "eval:doc.stone",
    "fieldname": "stone_weight",
    "fieldtype": "Float",
-   "in_list_view": 1,
    "label": "Stone Weight"
   },
   {
    "fieldname": "net_weight",
    "fieldtype": "Float",
+   "in_list_view": 1,
    "label": "Net Weight",
    "read_only": 1
   },
@@ -71,7 +71,6 @@
   {
    "fieldname": "stone",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Stone",
    "read_only": 1
   },
@@ -79,13 +78,11 @@
    "depends_on": "eval:doc.stone",
    "fieldname": "stone_charge",
    "fieldtype": "Currency",
-   "in_list_view": 1,
    "label": "Stone Charge"
   },
   {
    "fieldname": "making_charge",
    "fieldtype": "Currency",
-   "in_list_view": 1,
    "label": "Making Charge",
    "read_only": 1,
    "reqd": 1
@@ -117,7 +114,7 @@
    "reqd": 1
   },
   {
-   "default": "3000",
+   "depends_on": "eval:doc.has_stone == 1",
    "fieldname": "unit_stone_charge",
    "fieldtype": "Int",
    "label": "Unit Stone Charge"
@@ -132,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-01 13:18:13.905918",
+ "modified": "2024-03-02 12:37:02.932535",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Item Receipt",

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -37,14 +37,14 @@ frappe.ui.form.on("Jewellery Receipt", {
     }
     frm.refresh_fields();
   },
-  create_item: function(frm) {
+  add_multi_stone: function(frm) {
     if (frm.is_new()) {
-       create_item_details(frm);
+       create_multi_stone(frm);
     }
   }
 });
 
-let create_item_details = function(frm) {
+let create_multi_stone = function(frm) {
   let d = new frappe.ui.Dialog({
     title: 'Enter Item Details',
     fields: [
@@ -65,6 +65,12 @@ let create_item_details = function(frm) {
         label: 'Making Charge In Percentage',
         fieldname: 'making_charge_in_percentage',
         fieldtype: 'Percent',
+        reqd: 1
+      },
+      {
+        label: 'Unit of Stone Charge',
+        fieldname: 'unit_stone_charge',
+        fieldtype: 'Int',
         reqd: 1
       },
       {
@@ -94,12 +100,6 @@ let create_item_details = function(frm) {
         label: 'Total Stone Weight',
         fieldname: 'total_stone_weight',
         fieldtype: 'Float',
-      },
-      {
-        label: 'Unit of Stone Charge',
-        fieldname: 'unit_stone_charge',
-        fieldtype: 'Int',
-        default: 3000
       },
     ],
     primary_action_label: 'Submit',

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
@@ -11,7 +11,7 @@
   "item_type",
   "item_group",
   "supplier",
-  "is_fix",
+  "fixed_charge",
   "column_break_pnvl",
   "purity",
   "board_rate",
@@ -19,7 +19,7 @@
   "has_stone",
   "single_stone",
   "stone",
-  "create_item",
+  "add_multi_stone",
   "section_break_vxux",
   "item_details",
   "amended_from"
@@ -100,7 +100,8 @@
    "fieldname": "item_details",
    "fieldtype": "Table",
    "label": "Item Details",
-   "options": "Jewellery Item Receipt"
+   "options": "Jewellery Item Receipt",
+   "reqd": 1
   },
   {
    "fieldname": "amended_from",
@@ -121,28 +122,28 @@
   },
   {
    "default": "0",
-   "fieldname": "is_fix",
-   "fieldtype": "Check",
-   "label": "Fixed Charge"
-  },
-  {
-   "depends_on": "eval:doc.has_stone && doc.single_stone != 1",
-   "fieldname": "create_item",
-   "fieldtype": "Button",
-   "label": "Create Item"
-  },
-  {
-   "default": "0",
    "depends_on": "eval:doc.has_stone ==1",
    "fieldname": "single_stone",
    "fieldtype": "Check",
    "label": "Single Stone"
+  },
+  {
+   "depends_on": "eval:doc.has_stone && doc.single_stone != 1",
+   "fieldname": "add_multi_stone",
+   "fieldtype": "Button",
+   "label": "Add Multi Stone"
+  },
+  {
+   "default": "0",
+   "fieldname": "fixed_charge",
+   "fieldtype": "Check",
+   "label": "Fixed Charge"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-01 12:32:02.236025",
+ "modified": "2024-03-02 12:11:43.323723",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Receipt",


### PR DESCRIPTION
## Feature description
Set Aumms item doctype as read only after saving

## Is there any existing behavior change of other features due to this code change?
 No. 

## Was this feature tested on the browsers?
  - Chrome
