### PR TITLE
Fix:Fixed Issues in Customer Jewellery Order

### DIFF
--- a/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.js
+++ b/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.js
@@ -2,17 +2,32 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Customer Jewellery Order", {
-	refresh(frm) {
+	on_submit(frm) {
 		if (!frm.is_new()){
-			frm.add_custom_button('Jewellery Order', () => {
+			// frm.add_custom_button('Jewellery Order', () => {
 				frappe.call('aumms.aumms.doctype.customer_jewellery_order.customer_jewellery_order.create_jewellery_order', {
 					customer_jewellery_order : frm.doc.name
 				}).then(r =>{
 						frm.reload_doc();
 				});
-			},'Create');
+			// },'Create');
 		}
 	},
+	if (purity) {
+		frappe.call({
+			method: 'aumms.aumms.utils.get_board_rate',
+			args: {
+					'purity': d.purity,
+			},
+			callback: function(r) {
+				if (r.message) {
+					let board_rate = r.message
+					frappe.model.set_value(cdt, cdn, 'board_rate', board_rate);
+					frm.refresh_field('old_jewellery_items');
+				}
+			}
+		})
+	}
 });
 
 frappe.ui.form.on("Customer Jewellery Order Details",{

--- a/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.json
+++ b/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "CJO.#####",
  "creation": "2024-03-12 12:26:20.226352",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -11,19 +12,12 @@
   "column_break_r1uk",
   "customer_expected_total_weight",
   "customer_expected_amount",
-  "jewellery_order_details_section",
+  "purity",
+  "uom",
+  "order_item_details_section",
   "order_item",
-  "total_expected_weight_per_quantity",
-  "order_items_tab",
-  "item_category",
-  "item_quantity",
-  "column_break_aamf",
-  "item_type",
-  "expected_weight_per_quantity",
-  "feasible",
-  "description_section",
-  "item_design_attachment",
-  "item_design_description"
+  "amended_from",
+  "total_expected_weight_per_quantity"
  ],
  "fields": [
   {
@@ -46,6 +40,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Customer Expected Total Weight",
+   "precision": "2",
    "reqd": 1
   },
   {
@@ -67,76 +62,53 @@
    "label": "Customer Name"
   },
   {
-   "fieldname": "order_items_tab",
-   "fieldtype": "Tab Break",
-   "label": "Order Items"
-  },
-  {
-   "fieldname": "item_design_description",
-   "fieldtype": "Text Editor",
-   "label": "Item Design Description"
-  },
-  {
-   "fieldname": "item_design_attachment",
-   "fieldtype": "Attach",
-   "label": "Item Design Attachment",
-   "reqd": 1
-  },
-  {
-   "fieldname": "item_category",
-   "fieldtype": "Link",
-   "label": "Item Category",
-   "options": "Item Category"
-  },
-  {
-   "fieldname": "item_quantity",
-   "fieldtype": "Int",
-   "label": "Item Quantity"
-  },
-  {
-   "fieldname": "item_type",
-   "fieldtype": "Link",
-   "label": "Item Type",
-   "options": "Item Type"
-  },
-  {
-   "fieldname": "expected_weight_per_quantity",
-   "fieldtype": "Float",
-   "label": "Expected Weight Per Quantity"
-  },
-  {
-   "fieldname": "column_break_aamf",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "description_section",
-   "fieldtype": "Section Break",
-   "label": "Description"
-  },
-  {
    "fieldname": "order_item",
    "fieldtype": "Table",
    "label": "Order Item",
    "options": "Customer Jewellery Order Details"
   },
   {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Customer Jewellery Order",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "order_item_details_section",
+   "fieldtype": "Section Break",
+   "label": "Order item Details"
+  },
+  {
    "fieldname": "total_expected_weight_per_quantity",
    "fieldtype": "Float",
    "hidden": 1,
-   "label": "Total Expected Weight per Quantity",
-   "default": "0",
-   "fieldname": "feasible",
-   "fieldtype": "Check",
-   "label": "Feasible",
+   "label": "Total Customer Expected Weight Per Quantity"
+  },
+  {
+   "fieldname": "purity",
+   "fieldtype": "Link",
+   "label": "Purity",
+   "options": "Purity"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "UOM",
+   "options": "UOM"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-14 12:41:26.251019",
+ "modified": "2024-03-15 16:40:45.639559",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Customer Jewellery Order",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.py
+++ b/aumms/aumms/doctype/customer_jewellery_order/customer_jewellery_order.py
@@ -6,11 +6,9 @@ from frappe import _
 from frappe.model.document import Document
 
 class CustomerJewelleryOrder(Document):
-	pass
-
-    def validate(self):
-        if self.total_expected_weight_per_quantity != self.customer_expected_total_weight:
-            frappe.throw(_('The Sum of Expected Weights Per Quantity must be Equal to Customer Expected Weight'))
+	def validate(self):
+		if self.total_expected_weight_per_quantity != self.customer_expected_total_weight:
+			frappe.throw(_('The Sum of Expected Weights Per Quantity must be Equal to Customer Expected Weight'))
 
 
 @frappe.whitelist()
@@ -31,8 +29,14 @@ def create_jewellery_order(customer_jewellery_order):
                 jewellery_order.expected_weight_per_quantity = item.expected_weight_per_quantity
                 jewellery_order.design_attachment = item.item_design_attachment
                 jewellery_order.insert(ignore_permissions=True)
-                frappe.msgprint('Jewellery Order Created.', indicator="green", alert=1)
+            frappe.msgprint('{0} Jewellery Orders Created.'.format(len(doc.order_item)), indicator="green", alert=1)
         else:
             frappe.throw(_('Jewellery Order is already exist for {0}'.format(doc.name)))
     else:
         frappe.throw(_('Customer Jewellery Order {0} does not exist'.format(customer_jewellery_order)))
+
+@frappe.whitelist()
+def get_filtered_board_rate(purity):
+    # Fetch filtered board rate based on purity
+    board_rate = frappe.db.get_value("Board Rate", {"purity": purity})
+    return board_rate

--- a/aumms/aumms/doctype/customer_jewellery_order_details/customer_jewellery_order_details.json
+++ b/aumms/aumms/doctype/customer_jewellery_order_details/customer_jewellery_order_details.json
@@ -21,7 +21,7 @@
    "fieldname": "item_category",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Item Category",
+   "label": "Category",
    "options": "Item Category",
    "reqd": 1
   },
@@ -29,14 +29,14 @@
    "fieldname": "item_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Item Quantity",
+   "label": "Quantity",
    "reqd": 1
   },
   {
    "fieldname": "item_type",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Item Type",
+   "label": "Type",
    "options": "Item Type"
   },
   {
@@ -44,6 +44,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Expected Weight Per Quantity",
+   "precision": "2",
    "reqd": 1
   },
   {
@@ -62,7 +63,7 @@
   {
    "fieldname": "item_design_description",
    "fieldtype": "Text Editor",
-   "label": "Item Design Description"
+   "label": "Design Description"
   },
   {
    "fieldname": "column_break_poky",
@@ -77,7 +78,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-13 13:00:50.983408",
+ "modified": "2024-03-15 16:46:49.086084",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Customer Jewellery Order Details",


### PR DESCRIPTION
## Feature description

- Removed tab break order items and add child table and other details in detail section
- removed mandatory of field attach design
- removed the jewellery order button
- add naming series
- one message print with umber of jewellery order
- removed item in child table.

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/c39a1917-6d40-4550-bb81-22ec7d3a8c9d)

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
