### PR TITLE
feat: Added board amount calculation based on board rate

### DIFF
--- a/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.js
+++ b/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.js
@@ -2,33 +2,38 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Customer Jewellery Order", {
-	refresh(frm) {
-		if (!frm.is_new()){
-			frm.add_custom_button('Jewellery Order', () => {
-				frappe.call('aumms.aumms_manufacturing.doctype.customer_jewellery_order.customer_jewellery_order.create_jewellery_order', {
-					customer_jewellery_order : frm.doc.name
-				}).then(r =>{
-						frm.reload_doc();
-				});
-			},'Create');
-		}
-	},
+  customer_expected_total_weight: function (frm) {
+    calculate_customer_expected_amount(frm);
+  },
+  uom: function (frm) {
+    calculate_customer_expected_amount(frm);
+  },
+  purity: function (frm) {
+    calculate_customer_expected_amount(frm);
+  },
 });
 
-frappe.ui.form.on("Customer Jewellery Order Details",{
-  expected_weight_per_quantity: function(frm, cdt, cdn){
-   let d = locals[cdt][cdn];
-   var total_weightage = 0
-   frm.doc.order_item.forEach(function(d){
-     total_weightage += d.expected_weight_per_quantity * d.item_quantity;
-   })
-   frm.set_value('total_expected_weight_per_quantity',total_weightage)
- },
- order_item_remove:function(frm){
-     var total_weightage = 0
-     frm.doc.order_item.forEach(function(d){
-       total_weightage += d.expected_weight_per_quantity;
-     })
-     frm.set_value("total_expected_weight_per_quantity",total_weightage)
-   }
-})
+frappe.ui.form.on("Customer Jewellery Order Details", {
+  expected_weight_per_quantity: function (frm, cdt, cdn) {
+    let d = locals[cdt][cdn];
+    var total_weightage = 0;
+    frm.doc.order_item.forEach(function (d) {
+      total_weightage += d.expected_weight_per_quantity * d.item_quantity;
+    });
+    frm.set_value("total_expected_weight_per_quantity", total_weightage);
+  },
+
+  order_item_remove: function (frm) {
+    var total_weightage = 0;
+    frm.doc.order_item.forEach(function (d) {
+      total_weightage += d.expected_weight_per_quantity;
+    });
+    frm.set_value("total_expected_weight_per_quantity", total_weightage);
+  },
+});
+
+function calculate_customer_expected_amount(frm) {
+  if (frm.doc.customer_expected_total_weight && frm.doc.uom && frm.doc.purity) {
+    board_rate = frm.call("calculate_customer_expected_amount");
+  }
+}

--- a/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.json
+++ b/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:CJO{#####}",
  "creation": "2024-03-12 12:26:20.226352",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -10,14 +11,12 @@
   "required_date",
   "column_break_r1uk",
   "customer_expected_total_weight",
+  "uom",
+  "purity",
   "customer_expected_amount",
-  "order_items_tab",
-  "section_break_byiu",
+  "order_item_details_section",
   "order_item",
   "total_expected_weight_per_quantity",
-  "description_section",
-  "item_design_attachment",
-  "item_design_description",
   "amended_from"
  ],
  "fields": [
@@ -41,6 +40,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Customer Expected Total Weight",
+   "precision": "2",
    "reqd": 1
   },
   {
@@ -62,35 +62,10 @@
    "label": "Customer Name"
   },
   {
-   "fieldname": "order_items_tab",
-   "fieldtype": "Tab Break",
-   "label": "Order Items"
-  },
-  {
-   "fieldname": "item_design_description",
-   "fieldtype": "Text Editor",
-   "label": "Item Design Description"
-  },
-  {
-   "fieldname": "item_design_attachment",
-   "fieldtype": "Attach",
-   "label": "Item Design Attachment",
-   "reqd": 1
-  },
-  {
-   "fieldname": "description_section",
-   "fieldtype": "Section Break",
-   "label": "Description"
-  },
-  {
    "fieldname": "order_item",
    "fieldtype": "Table",
    "label": "Order Item",
    "options": "Customer Jewellery Order Details"
-  },
-  {
-   "fieldname": "section_break_byiu",
-   "fieldtype": "Section Break"
   },
   {
    "fieldname": "amended_from",
@@ -107,15 +82,34 @@
    "fieldtype": "Float",
    "hidden": 1,
    "label": "Total Expected Weight Per Quantity"
+  },
+  {
+   "default": "Gram",
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "UOM",
+   "options": "UOM"
+  },
+  {
+   "fieldname": "purity",
+   "fieldtype": "Link",
+   "label": "Purity",
+   "options": "Purity"
+  },
+  {
+   "fieldname": "order_item_details_section",
+   "fieldtype": "Section Break",
+   "label": "Order Item Details"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-15 15:39:49.434112",
+ "modified": "2024-03-16 14:18:28.844830",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Customer Jewellery Order",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.py
+++ b/aumms/aumms_manufacturing/doctype/customer_jewellery_order/customer_jewellery_order.py
@@ -5,32 +5,66 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+
 class CustomerJewelleryOrder(Document):
-	def validate(self):
-		if self.total_expected_weight_per_quantity != self.customer_expected_total_weight:
-			frappe.throw(_('The Sum of Expected Weights Per Quantity must be Equal to Customer Expected Weight'))
+    def validate(self):
+        if (
+            self.total_expected_weight_per_quantity
+            != self.customer_expected_total_weight
+        ):
+            frappe.throw(
+                _(
+                    "The Sum of Expected Weights Per Quantity must be Equal to Customer Expected Weight"
+                )
+            )
 
+    def on_submit(self):
+        self.create_jewellery_order()
 
-@frappe.whitelist()
-def create_jewellery_order(customer_jewellery_order):
-    if frappe.db.exists('Customer Jewellery Order', customer_jewellery_order):
-        doc = frappe.get_doc('Customer Jewellery Order', customer_jewellery_order)
-        if not frappe.db.exists('Jewellery Order', {'customer_jewellery_order': doc.name}):
-            for item in doc.order_item:
-                jewellery_order = frappe.new_doc('Jewellery Order')
-                jewellery_order.customer_jewellery_order = doc.name
-                jewellery_order.customer = doc.customer
-                jewellery_order.required_date = doc.required_date
-                jewellery_order.customer_expected_total_weight = doc.customer_expected_total_weight
-                jewellery_order.customer_expected_amount = doc.customer_expected_amount
-                jewellery_order.item_category = item.item_category
-                jewellery_order.item_type = item.item_type
-                jewellery_order.quantity = item.item_quantity
-                jewellery_order.expected_weight_per_quantity = item.expected_weight_per_quantity
-                jewellery_order.design_attachment = item.item_design_attachment
-                jewellery_order.insert(ignore_permissions=True)
-                frappe.msgprint('Jewellery Order Created.', indicator="green", alert=1)
+    def create_jewellery_order(self):
+        jewellery_order_exist = frappe.db.exists(
+            "Jewellery Order", {"customer_jewellery_order": self.name}
+        )
+        if not jewellery_order_exist:
+            for item in self.order_item:
+                new_jewellery_order = frappe.new_doc("Jewellery Order")
+                new_jewellery_order.customer_jewellery_order = self.name
+                new_jewellery_order.customer = self.customer
+                new_jewellery_order.required_date = self.required_date
+                new_jewellery_order.customer_expected_total_weight = (
+                    self.customer_expected_total_weight
+                )
+                new_jewellery_order.customer_expected_amount = (
+                    self.customer_expected_amount
+                )
+                new_jewellery_order.item_category = item.item_category
+                new_jewellery_order.item_type = item.item_type
+                new_jewellery_order.quantity = item.item_quantity
+                new_jewellery_order.expected_weight_per_quantity = (
+                    item.expected_weight_per_quantity
+                )
+                new_jewellery_order.design_attachment = item.item_design_attachment
+                new_jewellery_order.insert(ignore_permissions=True)
+                frappe.msgprint(
+                    f"Jewellery Order {new_jewellery_order.name} Created.",
+                    indicator="green",
+                    alert=1,
+                )
         else:
-            frappe.throw(_('Jewellery Order is already exist for {0}'.format(doc.name)))
-    else:
-        frappe.throw(_('Customer Jewellery Order {0} does not exist'.format(customer_jewellery_order)))
+            frappe.throw(_(f"Jewellery Order is already exist for {self.name}"))
+
+    @frappe.whitelist()
+    def calculate_customer_expected_amount(self):
+        exists = frappe.db.exists("Board Rate", {"purity": self.purity, "uom": "Gram"})
+        if exists:
+            latest_board_rate = frappe.get_last_doc(
+                "Board Rate", {"purity": self.purity, "uom": "Gram"}
+            )
+            board_rate_value = latest_board_rate.board_rate
+            self.customer_expected_amount = (
+                self.customer_expected_total_weight * board_rate_value
+            )
+        else:
+            frappe.throw(
+                f"No Board Rate found for Purity {self.purity} and UOM {self.uom}"
+            )

--- a/aumms/aumms_manufacturing/doctype/customer_jewellery_order_details/customer_jewellery_order_details.json
+++ b/aumms/aumms_manufacturing/doctype/customer_jewellery_order_details/customer_jewellery_order_details.json
@@ -21,7 +21,7 @@
    "fieldname": "item_category",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Item Category",
+   "label": "Category",
    "options": "Item Category",
    "reqd": 1
   },
@@ -29,14 +29,14 @@
    "fieldname": "item_quantity",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Item Quantity",
+   "label": "Quantity",
    "reqd": 1
   },
   {
    "fieldname": "item_type",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Item Type",
+   "label": "Type",
    "options": "Item Type"
   },
   {
@@ -44,6 +44,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Expected Weight Per Quantity",
+   "precision": "2",
    "reqd": 1
   },
   {
@@ -62,7 +63,7 @@
   {
    "fieldname": "item_design_description",
    "fieldtype": "Text Editor",
-   "label": "Item Design Description"
+   "label": "Design Description"
   },
   {
    "fieldname": "column_break_poky",
@@ -77,7 +78,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-15 15:45:06.659227",
+ "modified": "2024-03-16 14:04:39.973604",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Customer Jewellery Order Details",


### PR DESCRIPTION
## Feature description
- Customer Expected amount calculation based on Board Rate
- Creating Jewellery Order on Submit of Customer Jewellery Order

## Areas affected and ensured
DocType
- Customer Jewellery Order

## Is there any existing behavior change of other features due to this code change?
Yes
- Jewellery Order is now created on submit of the CJO

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
