### PR TITLE
feat:Fetch the raw_id of raw material bundle child table to the raw material request doctype

### DIFF
--- a/aumms/aumms_manufacturing/doctype/raw_material_bundle/raw_material_bundle.py
+++ b/aumms/aumms_manufacturing/doctype/raw_material_bundle/raw_material_bundle.py
@@ -29,6 +29,7 @@ class RawMaterialBundle(Document):
 					new_raw_materiel_request.required_quantity = raw_material.quantity - raw_material.available_quantity_in_stock
 					new_raw_materiel_request.item_name = raw_material.item_name
 					new_raw_materiel_request.item_type = raw_material.item_type
+					new_raw_materiel_request.raw_material_bundle = raw_material.raw_material_id
 					new_raw_materiel_request.insert(ignore_permissions=True)
 					raw_materiel_count += 1
 			frappe.msgprint(f"{raw_materiel_count} Raw Material Request Created.",indicator="green",alert=1,)

--- a/aumms/aumms_manufacturing/doctype/raw_material_details/raw_material_details.json
+++ b/aumms/aumms_manufacturing/doctype/raw_material_details/raw_material_details.json
@@ -6,7 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "raw_name",
+  "raw_material_id",
   "item_name",
   "item_type",
   "column_break_6dux",
@@ -45,15 +45,15 @@
    "label": "Available Quantity in Stock"
   },
   {
-   "fieldname": "raw_name",
+   "fieldname": "raw_material_id",
    "fieldtype": "Data",
-   "label": "Raw Name"
+   "label": "Raw Material Id"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-22 14:36:26.768393",
+ "modified": "2024-03-23 10:36:10.810244",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Raw Material Details",


### PR DESCRIPTION
## Feature description
Fetch the raw_id of raw material bundle child table to the raw material request doctype.

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/78d1b8a4-548c-4729-ac69-89ee74043ead)
![image](https://github.com/efeone/aumms/assets/84179426/b4aa56bf-3190-4f10-a2ab-1b97c4febb1f)

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
