### PR TITLE
fix: stages will be fetched on update in item category

### DIFF
--- a/aumms/aumms/doctype/item_category/item_category.py
+++ b/aumms/aumms/doctype/item_category/item_category.py
@@ -8,16 +8,32 @@ from frappe.model.document import Document
 
 class ItemCategory(Document):
 
-    def after_insert(self):
+    def before_save(self):
         self.update_stages()
 
     def update_stages(self):
+        """Fetches stages data from Manufacturing Stage Template and add it in Item Category's child table"""
         if self.manufacturing_stage_template:
-            manufacturing_stage_template = frappe.get_doc("Manufacturing Stage Template", self.manufacturing_stage_template)
-            for manufacturing_stage in manufacturing_stage_template.manufacturing_stages:
-                self.append("stages", {
-                    "stage": manufacturing_stage.stage,
-                    "default_workstation": manufacturing_stage.default_workstation,
-                    "required_time": manufacturing_stage.required_time
-                })
-            self.save()
+            manufacturing_stage_template = frappe.get_doc(
+                "Manufacturing Stage Template", self.manufacturing_stage_template
+            )
+            for (
+                manufacturing_stage
+            ) in manufacturing_stage_template.manufacturing_stages:
+                if not frappe.db.exists(
+                    "Manufacturing Stage Table",
+                    {
+                        "parent": self.name,
+                        "stage": manufacturing_stage.stage,
+                        "default_workstation": manufacturing_stage.default_workstation,
+                        "required_time": manufacturing_stage.required_time,
+                    },
+                ):
+                    self.append(
+                        "stages",
+                        {
+                            "stage": manufacturing_stage.stage,
+                            "default_workstation": manufacturing_stage.default_workstation,
+                            "required_time": manufacturing_stage.required_time,
+                        },
+                    )


### PR DESCRIPTION
## Issue description
stages were not getting fetched properly in Item category

## Solution description
Changed after insert controller to before save and checked if the stage already exist before inserting it.


## Areas affected and ensured
Item Category

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
