### PR TITLE
Category fetch for manufacturing request

### DIFF
--- a/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.py
+++ b/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.py
@@ -7,7 +7,18 @@ from frappe.model.mapper import get_mapped_doc
 
 
 class ManufacturingRequest(Document):
-	pass
+	def before_insert(self):
+		self.update_mingr_stages()
+	
+	def update_mingr_stages(self):
+		if self.category:
+			category_doc = frappe.get_doc('Item Category', self.category)
+			for stage in category_doc.stages:
+				self.append('manufacturing_request_stage', {
+					'manufacturing_stage': stage.stage,
+					'required_time': stage.required_time,
+					'workstation': stage.default_workstation
+				})
 
 @frappe.whitelist()
 def create_required_raw_material(source_name, target_doc=None):

--- a/aumms/aumms_manufacturing/doctype/manufacturing_request_stage/manufacturing_request_stage.json
+++ b/aumms/aumms_manufacturing/doctype/manufacturing_request_stage/manufacturing_request_stage.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "format:MRS.####",
+ "autoname": "format:MRS{####}",
  "creation": "2024-03-22 12:28:44.446996",
  "default_view": "List",
  "doctype": "DocType",
@@ -14,6 +14,7 @@
   "completed",
   "custom_column_break_lwydq",
   "assigned_to",
+  "required_time",
   "workstation"
  ],
  "fields": [
@@ -53,24 +54,32 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Workstation",
-   "options": "Workstation"
+   "options": "Workstation",
+   "read_only": 1
   },
   {
    "fieldname": "manufacturing_stage",
    "fieldtype": "Link",
    "label": "Manufacturing Stage",
-   "options": "Manufacturing Stage"
+   "options": "Manufacturing Stage",
+   "read_only": 1
   },
   {
    "fieldname": "select_raw_material",
    "fieldtype": "Button",
    "label": "Select Raw materiel"
+  },
+  {
+   "fieldname": "required_time",
+   "fieldtype": "Data",
+   "label": "Required Time",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-22 20:17:11.848888",
+ "modified": "2024-03-23 11:37:15.300108",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Manufacturing Request Stage",


### PR DESCRIPTION
## Feature description
Category Stages must be fetched in Manufacturing  Request when it is created from Jewellery Order

## Areas affected and ensured
Manufacturing Request

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
