### PR TITLE
fix: Autonaming in manufacturing request

### DIFF
--- a/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.json
+++ b/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.json
@@ -1,25 +1,29 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "format:{MR}-{#####}-{purity}-{uom}-{category}-{type}-{total_weight}",
  "creation": "2024-03-14 10:03:40.820137",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "raw_material_request_type",
   "raw_material_request",
+  "column_break_i3eg",
   "manufacturing_request",
   "jewellery_order",
+  "section_break_hpbr",
   "required_date",
   "quantity",
-  "design_attachment",
-  "column_break_jgee",
-  "status",
   "purity",
-  "uom",
+  "column_break_jgee",
   "category",
-  "type",
-  "amended_from",
+  "uom",
   "total_weight",
+  "column_break_jclf",
+  "status",
+  "type",
+  "design_attachment",
+  "amended_from",
   "section_break_sjns",
   "manufacturing_request_stage"
  ],
@@ -147,15 +151,28 @@
    "fieldtype": "Select",
    "label": "Status",
    "options": "Open\nCompleted\nCancelled"
+  },
+  {
+   "fieldname": "column_break_i3eg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_hpbr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_jclf",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-05 10:51:50.620467",
+ "modified": "2024-04-05 15:04:07.689855",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Manufacturing Request",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/aumms/aumms_manufacturing/doctype/manufacturing_request_stage/manufacturing_request_stage.json
+++ b/aumms/aumms_manufacturing/doctype/manufacturing_request_stage/manufacturing_request_stage.json
@@ -42,7 +42,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Assigned To",
-   "options": "Smith"
+   "options": "Smith",
+   "reqd": 1
   },
   {
    "fetch_from": "manufacturing_stage.default_workstation",
@@ -51,14 +52,16 @@
    "in_list_view": 1,
    "label": "Workstation",
    "options": "Workstation",
-   "read_only": 1
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "fieldname": "manufacturing_stage",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Manufacturing Stage",
-   "options": "Manufacturing Stage"
+   "options": "Manufacturing Stage",
+   "reqd": 1
   },
   {
    "fieldname": "select_raw_material",
@@ -97,7 +100,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-28 10:44:58.175133",
+ "modified": "2024-04-05 17:13:22.854255",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Manufacturing Request Stage",


### PR DESCRIPTION
## Feature description
Auto naming in manufacturing request

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/16bbd7a4-cb2d-4702-a0cf-6183d362bcbf)

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

