### PR TITLE
feat:Hide Create Raw Material Bundle button after submitting Raw Material Bundle and hide add row after saving manufacturing request

### DIFF
--- a/aumms/aumms_manufacturing/doctype/jewellery_order/jewellery_order.js
+++ b/aumms/aumms_manufacturing/doctype/jewellery_order/jewellery_order.js
@@ -29,6 +29,7 @@ frappe.ui.form.on("Jewellery Order", {
                 }
             }
         });
+				limit_item_details(frm)
     },
     quantity: function(frm) {
         limit_item_details(frm)
@@ -36,9 +37,6 @@ frappe.ui.form.on("Jewellery Order", {
     total_weight: function(frm) {
 			update_intro(frm)
     },
-		// on_save: function(frm) {
-		// 	update_intro(frm)
-		// }
 });
 
 

--- a/aumms/aumms_manufacturing/doctype/manufacturing__stage/manufacturing__stage.json
+++ b/aumms/aumms_manufacturing/doctype/manufacturing__stage/manufacturing__stage.json
@@ -136,7 +136,6 @@
    "default": "0",
    "fieldname": "raw_material_bundle_created",
    "fieldtype": "Check",
-   "hidden": 1,
    "label": "Raw Material Bundle Created",
    "read_only": 1
   }
@@ -144,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-16 11:10:49.390424",
+ "modified": "2024-04-16 16:24:56.714201",
  "modified_by": "Administrator",
  "module": "AuMMS Manufacturing",
  "name": "Manufacturing  Stage",

--- a/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.js
+++ b/aumms/aumms_manufacturing/doctype/manufacturing_request/manufacturing_request.js
@@ -27,6 +27,7 @@ frappe.ui.form.on("Manufacturing  Stage", {
       'manufacturing_request': frm.doc.name,
       'manufacturing_stage' : row.manufacturing_stages,
     })
+    row.raw_material_bundle_created = 1;
   },
 
   create_job_card: function(frm, cdt, cdn) {


### PR DESCRIPTION
## Feature description

- Hide Create Raw Material Bundle button after submitting Raw Material Bundle and a check box Raw Material Bundle Created.
- Hide add row in Child table after saving manufacturing request

## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/84179426/c824b00e-5891-40ba-bf92-41164ef82df5)
![image](https://github.com/efeone/aumms/assets/84179426/4064bb7a-3b55-46be-a2de-4427c9682957)

## Is there any existing behavior change of other features due to this code change?
No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox