### PR TITLE
feat:Job time childtable and duration field made read only

### DIFF
--- a/aumms/aumms_manufacturing/doctype/jewellery_job_card/jewellery_job_card.js
+++ b/aumms/aumms_manufacturing/doctype/jewellery_job_card/jewellery_job_card.js
@@ -8,6 +8,11 @@ frappe.ui.form.on("Jewellery Job Card", {
     if (frm.doc.docstatus === 1) {
       frm.remove_custom_button('Start');
     }
+    frm.set_df_property("duration", "read_only", 1);
+    frm.set_df_property("job_time", "read_only",frm.doc.__islocal ? 0 : 1);
+  },
+  onload: function(frm) {
+    frm.get_field('item_details').grid.cannot_add_rows = true;
   }
 });
 
@@ -107,6 +112,7 @@ frappe.ui.form.on('Raw Materiel Item',{
   item_details_remove : function(frm, cdt, cdn){
     calculate_total_weight(frm);
   }
+
 });
 
 function calculate_total_weight(frm, cdt, cdn){


### PR DESCRIPTION
## Feature description
Job time childtable and duration field made read only.Add row button removed from childtable.


## Output screenshots (optional)
![image](https://github.com/efeone/aumms/assets/161805733/7a6bb98f-149a-4019-91c0-541df01c52db)
![image](https://github.com/efeone/aumms/assets/161805733/e8ac194d-cc1b-48ce-bd38-ab5d914a83a0)

## Is there any existing behavior change of other features due to this code change?
      No. 

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox

