### PR TITLE
fix: remove dependance on common party accounting

### DIFF
--- a/aumms/hooks.py
+++ b/aumms/hooks.py
@@ -160,7 +160,6 @@ doc_events = {
 		'on_update': 'aumms.aumms.doc_events.item.update_uoms_table'
 	},
 	'Purchase Receipt': {
-		'before_submit': 'aumms.aumms.utils.validate_party_for_metal_transaction',
 		'on_submit': [
 			'aumms.aumms.utils.create_metal_ledger_entries',
 			'aumms.aumms.doc_events.purchase_receipt.purchase_receipt_on_submit'
@@ -168,7 +167,6 @@ doc_events = {
 		'on_cancel': 'aumms.aumms.utils.cancel_metal_ledger_entries'
 	},
 	'Sales Invoice': {
-		'before_submit': 'aumms.aumms.utils.validate_party_for_metal_transaction',
 		'on_submit': [
 			  'aumms.aumms.utils.create_metal_ledger_entries'
 		],


### PR DESCRIPTION
## Issue description
Currently, the accounting depends on common party accounting, which doesn't make sense in a sales only scenario

## Solution description
Removed the validation that checks for common-party existence on actions in accounting.

## Output screenshots
![image](https://github.com/efeone/aumms/assets/91651425/47357289-bdcd-4fd2-9a1c-43fc88b916f4)

## Areas affected and ensured
Jewellery Invoice
Hook

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox 
  - Opera Mini
  - Safari
