### PR TITLE
feat:add validation for Item Wise Stone Details

### DIFF
--- a/aumms/aumms/doctype/item_wise_stone_details/item_wise_stone_details.json
+++ b/aumms/aumms/doctype/item_wise_stone_details/item_wise_stone_details.json
@@ -28,6 +28,7 @@
    "options": "AuMMS Item"
   },
   {
+   "default": "Gram",
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -56,7 +57,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-08-20 10:07:11.991708",
+ "modified": "2025-02-13 15:16:58.071888",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Item Wise Stone Details",

--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -68,7 +68,7 @@
   {
    "fieldname": "net_weight",
    "fieldtype": "Float",
-   "label": "Total Weight",
+   "label": "Gross Weight",
    "read_only": 1
   },
   {
@@ -105,7 +105,7 @@
    "read_only": 1
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "has_stone",
    "fieldtype": "Check",
    "label": "Has Stone"

--- a/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
+++ b/aumms/aumms/doctype/jewellery_item_receipt/jewellery_item_receipt.json
@@ -194,7 +194,8 @@
    "fieldname": "stone_weight_gold_weight_uom",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Stone Weight (Gold Weight UOM)"
+   "label": "Stone Weight (Gold Weight UOM)",
+   "read_only": 1
   },
   {
    "default": "Gram",
@@ -233,7 +234,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-01-20 12:56:15.072112",
+ "modified": "2025-02-13 15:11:59.142367",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Item Receipt",

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -433,6 +433,12 @@ function set_sub_category_filter(frm) {
 frappe.ui.form.on("Item Wise Stone Details", {
   item_wise_stone_details_remove: function (frm, cdt, cdn) {
     update_stone_weight_and_charge(frm);
+  },
+  stone_weight: function (frm, cdt, cdn) {
+  update_stone_weight_and_charge(frm);
+  },
+  rate: function (frm, cdt, cdn) {
+  update_stone_weight_and_charge(frm);
   }
 });
 

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -9,6 +9,15 @@ frappe.ui.form.on("Jewellery Receipt", {
     });
   },
   refresh: function (frm) {
+    frm.fields_dict["item_wise_stone_details"].grid.wrapper.on(
+    "click",
+    ".grid-remove-row",
+    function () {
+      setTimeout(() => {
+        update_stone_weight_gold_weight_uom(frm);
+      }, 100);
+    }
+    );
     frm.set_query("stone", "item_details", () => {
       return {
         filters: {
@@ -420,4 +429,22 @@ function set_sub_category_filter(frm) {
       },
     };
   });
+}
+frappe.ui.form.on("Item Wise Stone Details", {
+  item_wise_stone_details_remove: function (frm, cdt, cdn) {
+    update_stone_weight_gold_weight_uom(frm);
+  }
+});
+
+function update_stone_weight_gold_weight_uom(frm) {
+  frm.doc.item_details.forEach((item) => {
+    item.stone_weight_gold_weight_uom = 0;
+  });
+  frm.doc.item_wise_stone_details.forEach((stone_row) => {
+    let parent_row = frm.doc.item_details.find((item) => item.idx === stone_row.reference);
+    if (parent_row) {
+      parent_row.stone_weight_gold_weight_uom += stone_row.stone_weight;
+    }
+  });
+  frm.refresh_field("item_details");
 }

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -14,7 +14,7 @@ frappe.ui.form.on("Jewellery Receipt", {
     ".grid-remove-row",
     function () {
       setTimeout(() => {
-        update_stone_weight_gold_weight_uom(frm);
+        update_stone_weight_and_charge(frm);
       }, 100);
     }
     );
@@ -432,18 +432,20 @@ function set_sub_category_filter(frm) {
 }
 frappe.ui.form.on("Item Wise Stone Details", {
   item_wise_stone_details_remove: function (frm, cdt, cdn) {
-    update_stone_weight_gold_weight_uom(frm);
+    update_stone_weight_and_charge(frm);
   }
 });
 
-function update_stone_weight_gold_weight_uom(frm) {
+function update_stone_weight_and_charge(frm) {
   frm.doc.item_details.forEach((item) => {
     item.stone_weight_gold_weight_uom = 0;
+    item.stone_charge = 0;
   });
   frm.doc.item_wise_stone_details.forEach((stone_row) => {
     let parent_row = frm.doc.item_details.find((item) => item.idx === stone_row.reference);
     if (parent_row) {
       parent_row.stone_weight_gold_weight_uom += stone_row.stone_weight;
+      parent_row.stone_charge += stone_row.rate * stone_row.stone_weight;
     }
   });
   frm.refresh_field("item_details");

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -18,6 +18,10 @@ frappe.ui.form.on("Jewellery Receipt", {
     });
     set_sub_category_filter(frm);
   },
+  onload: function (frm) {
+    frm.fields_dict["item_wise_stone_details"].grid.cannot_add_rows = true;
+    frm.refresh_field("item_wise_stone_details");
+  },
   item_sub_category: function (frm) {
     frm.events.update_item_details_table(frm);
   },
@@ -202,14 +206,26 @@ frappe.ui.form.on("Jewellery Item Receipt", {
   },
   add_stone: function (frm, cdt, cdn) {
     let row = locals[cdt][cdn];
+    if (row.has_stone) {
+    if (!row.stone || !row.stone_uom || !row.stone_weight || !row.rate) {
+        frappe.msgprint(__(
+          'Please ensure all stone details are filled before adding.'));
+        return;
+    }
+
     frm.add_child("item_wise_stone_details", {
-      reference: row.idx,
-      stone: row.stone,
-      uom: row.stone_uom,
-      stone_weight: row.stone_weight,
-      rate: row.rate,
-      amount: row.rate * row.stone_weight,
+        reference: row.idx,
+        stone: row.stone,
+        uom: row.stone_uom,
+        stone_weight: row.stone_weight,
+        rate: row.rate,
+        amount: row.rate * row.stone_weight,
     });
+
+    frm.refresh_field("item_wise_stone_details");
+    } else {
+        frappe.msgprint(__('Has Stone must be checked to add a stone.'));
+    }
 
     if (row.stone_weight_gold_weight_uom)
       row.stone_weight_gold_weight_uom += row.stone_weight;

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -120,28 +120,46 @@ frappe.ui.form.on("Jewellery Receipt", {
     if (quantity < cur_items_len) {
       frm.doc.item_details.splice(quantity);
     } else {
-      for (var i = cur_items_len; i < quantity; i++) {
-        let row = frm.add_child("item_details", {
-          item_category: frm.doc.item_category,
-          item_type: frm.doc.item_type,
-          item_group: frm.doc.item_group,
-          purity: frm.doc.purity,
-          board_rate: frm.doc.board_rate,
+      frappe.db
+        .get_value(
+          "Item Sub Category",
+          frm.doc.item_sub_category,
+          "making_charge_in_percentage"
+        )
+        .then((r) => {
+          console.log("here1");
+          console.log(cur_items_len);
+          console.log(quantity);
+          
+          
+          for (var i = cur_items_len; i < quantity; i++) {
+            console.log("loop");
+            
+            frm.add_child("item_details", {
+              item_category: frm.doc.item_category,
+              item_type: frm.doc.item_type,
+              item_group: frm.doc.item_group,
+              purity: frm.doc.purity,
+              board_rate: frm.doc.board_rate,
+              making_chargein_percentage: r.message.making_charge_in_percentage,
+            });
+            frm.refresh_fields()
+          }
         });
-      }
+      
     }
 
     frm.refresh_field("item_details");
   },
 });
 frappe.ui.form.on("Jewellery Item Receipt", {
-  form_render: function (frm, cdt, cdn) {
-    let d = locals[cdt][cdn];
-    if (d.has_stone) {
-      let net_weight = d.gold_weight + d.stone_weight;
-      frappe.model.set_value(cdt, cdn, "net_weight", net_weight);
-    }
-  },
+  // form_render: function (frm, cdt, cdn) {
+  //   let d = locals[cdt][cdn];
+  //   if (d.has_stone) {
+  //     let net_weight = d.gold_weight + d.stone_weight;
+  //     frappe.model.set_value(cdt, cdn, "net_weight", net_weight);
+  //   }
+  // }, kept for future reference
   stone_weight: function (frm, cdt, cdn) {
     let d = locals[cdt][cdn];
     if (d.single_stone) {
@@ -167,7 +185,7 @@ frappe.ui.form.on("Jewellery Item Receipt", {
   },
   gold_weight: function (frm, cdt, cdn) {
     let d = locals[cdt][cdn];
-    if (!d.has_stone) {
+    if (!d.has_stone || !d.stone_charge) {
       let net_weight = d.gold_weight;
       frappe.model.set_value(cdt, cdn, "net_weight", net_weight);
       let amount_without_making_charge = d.gold_weight * frm.doc.board_rate;

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -201,6 +201,7 @@ frappe.ui.form.on("Jewellery Item Receipt", {
         d.amount_without_making_charge * (d.making_chargein_percentage / 100);
       frappe.model.set_value(cdt, cdn, "making_charge", making_charge);
     }
+    frm.call("calculate_item_details")
   },
   making_chargein_percentage: function (frm, cdt, cdn) {
     let d = locals[cdt][cdn];
@@ -262,13 +263,17 @@ frappe.ui.form.on("Jewellery Item Receipt", {
     else row.stone_charge = row.rate * row.stone_weight;
 
     row.stone = "";
-    row.stone_uom = "";
+    row.stone_uom = "Gram";
     row.stone_weight = "";
     row.rate = "";
 
     frm.refresh_field("item_wise_stone_details");
     frm.refresh_field("item_details");
+    frm.call("calculate_item_details")
   },
+  board_rate: function(frm) {
+    frm.call("calculate_item_details")
+  }
 });
 
 let create_multi_stone = function (frm, cdt, cdn) {

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
@@ -18,6 +18,7 @@
   "board_rate",
   "date",
   "quantity",
+  "total_gold_weight",
   "section_break_vxux",
   "item_details",
   "item_wise_stone_details",
@@ -129,6 +130,13 @@
    "label": "Item Sub Category",
    "options": "Item Sub Category",
    "reqd": 1
+  },
+  {
+   "fieldname": "total_gold_weight",
+   "fieldtype": "Float",
+   "label": "Total Gold Weight",
+   "precision": "2",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.json
@@ -121,8 +121,7 @@
    "fieldname": "item_wise_stone_details",
    "fieldtype": "Table",
    "label": "Item Wise Stone Details",
-   "options": "Item Wise Stone Details",
-   "read_only": 1
+   "options": "Item Wise Stone Details"
   },
   {
    "fieldname": "item_sub_category",
@@ -135,7 +134,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-20 14:25:31.637164",
+ "modified": "2025-02-13 15:28:43.982739",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "Jewellery Receipt",

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
@@ -19,6 +19,12 @@ class JewelleryReceipt(Document):
 
 	def validate(self):
 		self.validate_date()
+  
+	def before_save(self):
+		total_gold_weight = 0
+		for item in self.item_details:
+			total_gold_weight += item.gold_weight
+		self.total_gold_weight = total_gold_weight
 
 	def on_submit(self):
 		self.create_item()

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.py
@@ -96,6 +96,7 @@ class JewelleryReceipt(Document):
 		purchase_receipt.submit()
 		frappe.msgprint('Purchase Receipt created.', indicator="green", alert=1)
 
+	@frappe.whitelist()
 	def calculate_item_details(self):
 		for item_detail in self.get("item_details"):
 			board_rate = self.board_rate or 0


### PR DESCRIPTION
## Feature description
- Added validation for Jewellery Receipt doctype

## Solution description
- Added validation for add row button in Item Details child table 
- hide add row button in Item Wise Stone Details
- set default value 'Gram' for uom in Item Wise Stone Details
- remove mandatory Item Wise Stone Details
- Update stone_weight_gold_weight_uom on row deletion in item_wise_stone_details

## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/d30a67e4-1c3c-4b7b-9cd9-565943241338)
![image](https://github.com/user-attachments/assets/67c72e17-3e73-48c0-996b-2c0f6d6ad551)
![image](https://github.com/user-attachments/assets/5b436ff6-ed9a-42fe-bdb0-a2806b72026a)
![image](https://github.com/user-attachments/assets/64672eca-13da-4f47-ad72-0fae9f72780f)
![image](https://github.com/user-attachments/assets/2bed57ee-fba9-4a2c-b5e6-eefd758868d7)



## Areas affected and ensured
Jewellery Receipt doctype

## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - yes
  - Opera Mini
  - Safari
