### PR TITLE
feat:make stone-related fields mandatory in Jewellery Receipt based on 'has_stone' property

### DIFF
--- a/aumms/aumms/doctype/aumms_item/aumms_item.json
+++ b/aumms/aumms/doctype/aumms_item/aumms_item.json
@@ -369,7 +369,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-11-05 12:06:59.188117",
+ "modified": "2025-03-19 13:09:02.575621",
  "modified_by": "Administrator",
  "module": "AuMMS",
  "name": "AuMMS Item",
@@ -413,7 +413,6 @@
    "write": 1
   }
  ],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
+++ b/aumms/aumms/doctype/jewellery_receipt/jewellery_receipt.js
@@ -130,11 +130,8 @@ frappe.ui.form.on("Jewellery Receipt", {
           console.log("here1");
           console.log(cur_items_len);
           console.log(quantity);
-          
-          
           for (var i = cur_items_len; i < quantity; i++) {
             console.log("loop");
-            
             frm.add_child("item_details", {
               item_category: frm.doc.item_category,
               item_type: frm.doc.item_type,
@@ -146,7 +143,7 @@ frappe.ui.form.on("Jewellery Receipt", {
             frm.refresh_fields()
           }
         });
-      
+
     }
 
     frm.refresh_field("item_details");
@@ -462,6 +459,24 @@ frappe.ui.form.on("Item Wise Stone Details", {
   },
   rate: function (frm, cdt, cdn) {
   update_stone_weight_and_charge(frm);
+  }
+});
+
+frappe.ui.form.on("Jewellery Receipt", {
+  refresh: function (frm) {
+    frm.doc.item_details?.forEach(row => frm.events.set_stone_fields_mandatory(frm, row));
+  },
+  set_stone_fields_mandatory: function (frm, row) {
+    ["stone", "stone_uom", "stone_weight", "rate"].forEach(field =>
+      frm.fields_dict["item_details"].grid.update_docfield_property(field, "reqd", row.has_stone)
+    );
+    frm.refresh_field("item_details");
+  }
+});
+
+frappe.ui.form.on("Jewellery Item Receipt", {
+  has_stone: function (frm, cdt, cdn) {
+    frm.events.set_stone_fields_mandatory(frm, locals[cdt][cdn]);
   }
 });
 


### PR DESCRIPTION

## Feature description
make stone-related fields mandatory in Jewellery Receipt based on 'has_stone' property


## Solution description
This update ensures that stone-related fields (stone, stone_uom, stone_weight, and rate) in the Jewellery Receipt form become mandatory when the has_stone checkbox is checked for a row in the Jewellery Item Receipt child table.
## Output screenshots (optional)
![image](https://github.com/user-attachments/assets/5a70ae7f-ef43-4f73-b6f2-871e0d00b542)

![image](https://github.com/user-attachments/assets/34cc7fef-92b3-4a9f-8e52-66d0656e75ec)

Post the output screenshots, if a UI is affected or added due to this feature.

## Areas affected and ensured
Jewellery Receipt
## Is there any existing behavior change of other features due to this code change?
Mention Yes or No. If Yes, provide the appropriate explanation.

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
